### PR TITLE
Remove FCM push notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.7.0
+
+- Admin moderation screens for reviewing pending image uploads and edits
+- Firebase Cloud Messaging (FCM) push notifications for admin alerts
+- Admin custom claims support in user provider
+- Urbanist font via google_fonts
+- Map control buttons (user tracking + pitch/angle toggle) on right side of map
+- Pitch button auto-deactivates when user manually tilts the map
+- Sliding panel: snap points (peek / 40% / 95%), no drag-to-dismiss, scrim at full height
+- Panel content not scrollable unless fully expanded
+- Search bar hidden only when panel is fully expanded
+- Map re-centering accounts for search bar and panel height
+- Panel max height respects safe area (below Dynamic Island/camera)
+
 ## 1.6.1
 
 - fix the search layout bug introduced in v1.6.0

--- a/README.md
+++ b/README.md
@@ -31,31 +31,25 @@ ACCESS_TOKEN=pk.your_mapbox_access_token_here
    - Add `google-services.json` to `android/app/`
    - Add `GoogleService-Info.plist` to `ios/Runner/`
 
-### Running the App
 
-- Choose a device in the bottom right of VS Code (make sure the emulator/simulator are running)
-- Use the `Run and Debug` panel in VS Code
-- Press the green play button ("Start Debugging")
 
-### VS Code Setup
+## Run on simulator/emulator
 
-The project includes launch configuration. Set your `ACCESS_TOKEN` environment variable:
-```bash
-export ACCESS_TOKEN=pk.your_token_here
-```
+`source .env && flutter run --dart-define=ACCESS_TOKEN=$ACCESS_TOKEN`
 
-### Production build to a real iOS device
+## Production build to my device
 
-This step is helpful for testing the build before releasing.
+`source .env && flutter run --release --dart-define=ACCESS_TOKEN=$ACCESS_TOKEN`
 
-- connect device via USB
-- choose device in VS Code (bottom-right blue bar)
-- flutter run --release --dart-define ACCESS_TOKEN=pk.12345
+You may need to add `-d <device_id>` if you have multiple devices connected. You can find the device id by running `flutter devices`.
+
+`source .env && flutter run --release --dart-define=ACCESS_TOKEN=$ACCESS_TOKEN -d 00008140-00061DE80106801C`
 
 ## Releasing
 
 ### Android Release
 
+- Add entry to CHANGELOG.md
 - increment version in `pubspec.yaml`
 - `sh scripts/build_android.sh`
 
@@ -67,6 +61,7 @@ Login to Google Play Console
 
 **Important**: before releasing, do a local release to a real device to test (see above) 
 
+- Add entry to CHANGELOG.md
 - increment version in `pubspec.yaml`
 - `sh scripts/build_ios.sh`
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,13 +5,10 @@ import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:cloud_firestore/cloud_firestore.dart' as firestore;
-
-import 'admin_moderation_screen.dart';
 
 import 'colors.dart';
 import 'map_screen.dart';
@@ -21,65 +18,6 @@ import 'public_space_properties.dart';
 import 'user_provider.dart';
 import 'username_input_screen.dart';
 import 'geojson_provider.dart';
-
-// Must be a top-level function for background message handling
-@pragma('vm:entry-point')
-Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  // Background messages are displayed automatically by FCM; no extra work needed here.
-  debugPrint('Background FCM message: ${message.messageId}');
-}
-
-Future<void> initFCM(BuildContext context) async {
-  FirebaseMessaging messaging = FirebaseMessaging.instance;
-
-  // Request permission (required on iOS, harmless on Android)
-  await messaging.requestPermission(
-    alert: true,
-    badge: true,
-    sound: true,
-  );
-
-  // Handle foreground messages as a snackbar
-  FirebaseMessaging.onMessage.listen((RemoteMessage message) {
-    final notification = message.notification;
-    if (notification != null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('${notification.title}: ${notification.body}'),
-          action: SnackBarAction(
-            label: 'Review',
-            onPressed: () {
-              navigatorKey.currentState?.push(
-                MaterialPageRoute(
-                  builder: (_) => const AdminModerationScreen(),
-                ),
-              );
-            },
-          ),
-          duration: const Duration(seconds: 6),
-        ),
-      );
-    }
-  });
-
-  // Handle notification tap when app is in background (not terminated)
-  FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
-    navigatorKey.currentState?.push(
-      MaterialPageRoute(builder: (_) => const AdminModerationScreen()),
-    );
-  });
-
-  // Handle notification tap when app was terminated
-  final initialMessage = await FirebaseMessaging.instance.getInitialMessage();
-  if (initialMessage != null) {
-    // Delay to let the app finish building before navigating
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      navigatorKey.currentState?.push(
-        MaterialPageRoute(builder: (_) => const AdminModerationScreen()),
-      );
-    });
-  }
-}
 
 Future<void> initDynamicLinks(BuildContext context) async {
   print('Initializing dynamic links...');
@@ -167,7 +105,6 @@ void main() {
     // debugPaintSizeEnabled = true; // For debugging purposes
 
     await Firebase.initializeApp();
-    FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
     firestore.FirebaseFirestore.instance.settings =
         const firestore.Settings(persistenceEnabled: false);
     runApp(
@@ -260,8 +197,6 @@ class _HomeScreenState extends State<HomeScreen> {
     super.initState();
     // Initialize dynamic links handling
     initDynamicLinks(context);
-    // Initialize FCM push notifications
-    initFCM(context);
 
     // Initialize the list of pages with the feedback tap handler
     _pages = <Widget>[

--- a/lib/user_provider.dart
+++ b/lib/user_provider.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_messaging/firebase_messaging.dart';
-
 import 'main.dart';
 
 class UserProvider with ChangeNotifier {
@@ -31,17 +29,7 @@ class UserProvider with ChangeNotifier {
 
       // Check for editor role via custom claims
       final idTokenResult = await user.getIdTokenResult(true);
-      final wasEditor = _isEditor;
       _isEditor = idTokenResult.claims?['role'] == 'editor';
-
-      // Subscribe/unsubscribe from admin FCM topic based on role
-      if (_isEditor && !wasEditor) {
-        await FirebaseMessaging.instance.subscribeToTopic('admin-notifications');
-        debugPrint('Subscribed to admin-notifications topic');
-      } else if (!_isEditor && wasEditor) {
-        await FirebaseMessaging.instance.unsubscribeFromTopic('admin-notifications');
-        debugPrint('Unsubscribed from admin-notifications topic');
-      }
 
       _isAuthenticated = true;
       notifyListeners();
@@ -72,9 +60,6 @@ class UserProvider with ChangeNotifier {
   }
 
   Future<void> signOut() async {
-    if (_isEditor) {
-      await FirebaseMessaging.instance.unsubscribeFromTopic('admin-notifications');
-    }
     await FirebaseAuth.instance.signOut();
     _isAuthenticated = false;
     _username = null;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -265,30 +265,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.6+46"
-  firebase_messaging:
-    dependency: "direct main"
-    description:
-      name: firebase_messaging
-      sha256: "4d0968ecb860d7baa15a6e2af3469ec5b0d959e51c59ce84a52b0f7632a4aa5a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "15.1.5"
-  firebase_messaging_platform_interface:
-    dependency: transitive
-    description:
-      name: firebase_messaging_platform_interface
-      sha256: a2cb3e7d71d40b6612e2d4e0daa0ae759f6a9d07f693f904d14d22aadf70be10
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.5.48"
-  firebase_messaging_web:
-    dependency: transitive
-    description:
-      name: firebase_messaging_web
-      sha256: "1554e190f0cd9d6fe59f61ae0275ac12006fdb78b07669f1a260d1a9e6de3a1f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.9.4"
   firebase_storage:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -50,7 +50,6 @@ dependencies:
   http: ^1.2.2
   uuid: ^4.5.0
   fuzzy: ^0.5.1
-  firebase_messaging: ^15.1.3
   google_fonts: ^8.0.0
   flutter_svg: ^2.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.6.1+10
+version: 1.7.0+11
 
 environment:
   sdk: ^3.5.1


### PR DESCRIPTION
## Summary

- Removes Firebase Cloud Messaging (FCM) integration that was causing an unwanted notification permission prompt on launch
- Removes `firebase_messaging` dependency from `pubspec.yaml`
- Admin screens remain intact — notifications can be re-added later

## Changes

- `lib/main.dart` — removed `initFCM()`, background message handler, and FCM imports
- `lib/user_provider.dart` — removed FCM topic subscribe/unsubscribe logic
- `pubspec.yaml` — removed `firebase_messaging: ^15.1.3`

## Test plan

- [ ] App launches without triggering a notification permission prompt
- [ ] Admin moderation screens still accessible and functional
- [ ] Sign in / sign out still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)