### PR TITLE
Add activity feed tab with per-space contribution history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.3
+
+- Pin mapbox_maps_flutter to 2.21.1 to fix iOS build
+
 ## 1.7.2
 
 - Add account deletion feature (App Store Guideline 5.1.1(v) compliance)

--- a/lib/activity_feed_screen.dart
+++ b/lib/activity_feed_screen.dart
@@ -1,0 +1,346 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:provider/provider.dart';
+import 'package:timeago/timeago.dart' as timeago;
+
+import 'colors.dart';
+import 'geojson_provider.dart';
+import 'public_space_properties.dart';
+
+class ActivityItem {
+  final String id;
+  final String type; // 'photo' or 'edit'
+  final String spaceId;
+  final String userId;
+  final String username;
+  final DateTime timestamp;
+
+  ActivityItem({
+    required this.id,
+    required this.type,
+    required this.spaceId,
+    required this.userId,
+    required this.username,
+    required this.timestamp,
+  });
+}
+
+class ActivityFeedScreen extends StatefulWidget {
+  final Function(String spaceId) onSpaceSelected;
+
+  const ActivityFeedScreen({super.key, required this.onSpaceSelected});
+
+  @override
+  State<ActivityFeedScreen> createState() => _ActivityFeedScreenState();
+}
+
+class _ActivityFeedScreenState extends State<ActivityFeedScreen> {
+  List<ActivityItem> _allItems = [];
+  List<ActivityItem> _myItems = [];
+  bool _loading = true;
+  String? _error;
+
+  StreamSubscription<QuerySnapshot>? _imagesSubscription;
+  StreamSubscription<QuerySnapshot>? _editsSubscription;
+  List<ActivityItem> _imageItems = [];
+  List<ActivityItem> _editItems = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribeToFeeds();
+  }
+
+  @override
+  void dispose() {
+    _imagesSubscription?.cancel();
+    _editsSubscription?.cancel();
+    super.dispose();
+  }
+
+  void _subscribeToFeeds() {
+    final db = FirebaseFirestore.instance;
+
+    _imagesSubscription = db
+        .collection('images')
+        .where('status', isEqualTo: 'approved')
+        .orderBy('timestamp', descending: true)
+        .limit(100)
+        .snapshots()
+        .listen(
+      (snapshot) {
+        _imageItems = snapshot.docs.map((doc) {
+          final data = doc.data();
+          final ts = data['timestamp'] as Timestamp?;
+          return ActivityItem(
+            id: doc.id,
+            type: 'photo',
+            spaceId: data['spaceId'] as String? ?? '',
+            userId: data['userId'] as String? ?? '',
+            username: data['username'] as String? ?? 'someone',
+            timestamp: ts?.toDate() ?? DateTime.now(),
+          );
+        }).toList();
+        _rebuildList();
+      },
+      onError: (e) {
+        // ignore: avoid_print
+        print('ActivityFeed images error: $e');
+        setState(() => _error = e.toString());
+      },
+    );
+
+    _editsSubscription = db
+        .collection('public-spaces-edits')
+        .where('status', isEqualTo: 'approved')
+        .orderBy('timestamp', descending: true)
+        .limit(100)
+        .snapshots()
+        .listen(
+      (snapshot) {
+        _editItems = snapshot.docs.map((doc) {
+          final data = doc.data();
+          final ts = data['timestamp'] as Timestamp?;
+          return ActivityItem(
+            id: doc.id,
+            type: 'edit',
+            spaceId: data['spaceId'] as String? ?? '',
+            userId: data['userId'] as String? ?? '',
+            username: data['userName'] as String? ?? 'someone',
+            timestamp: ts?.toDate() ?? DateTime.now(),
+          );
+        }).toList();
+        _rebuildList();
+      },
+      onError: (e) {
+        // ignore: avoid_print
+        print('ActivityFeed edits error: $e');
+        setState(() => _error = e.toString());
+      },
+    );
+  }
+
+  void _rebuildList() {
+    final currentUser = FirebaseAuth.instance.currentUser;
+    final merged = [..._imageItems, ..._editItems];
+    merged.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    setState(() {
+      _allItems = merged;
+      _myItems = currentUser != null
+          ? merged.where((item) => item.userId == currentUser.uid).toList()
+          : [];
+      _loading = false;
+    });
+  }
+
+  PublicSpaceFeature? _getFeature(
+      String spaceId, List<PublicSpaceFeature> features) {
+    try {
+      return features.firstWhere((f) => f.properties.firestoreId == spaceId);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  String? _boroughFromFeature(PublicSpaceFeature feature) {
+    final lat = feature.geometry.coordinates.lat.toDouble();
+    final lng = feature.geometry.coordinates.lng.toDouble();
+    // Staten Island first — isolated enough that simple bounds work reliably
+    if (lat >= 40.4774 && lat <= 40.6501 && lng >= -74.2591 && lng <= -74.0341) {
+      return 'Staten Island';
+    }
+    if (lat >= 40.6999 && lat <= 40.8816 && lng >= -74.0479 && lng <= -73.9067) {
+      return 'Manhattan';
+    }
+    if (lat >= 40.7855 && lat <= 40.9176 && lng >= -73.9339 && lng <= -73.7654) {
+      return 'Bronx';
+    }
+    if (lat >= 40.5707 && lat <= 40.7395 && lng >= -74.0421 && lng <= -73.8333) {
+      return 'Brooklyn';
+    }
+    if (lat >= 40.5431 && lat <= 40.8007 && lng >= -73.9625 && lng <= -73.7004) {
+      return 'Queens';
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          backgroundColor: Colors.white,
+          surfaceTintColor: Colors.transparent,
+          title: const Text(
+            'Activity',
+            style: TextStyle(fontWeight: FontWeight.bold),
+          ),
+          bottom: const TabBar(
+            labelColor: AppColors.dark,
+            unselectedLabelColor: AppColors.gray,
+            indicatorColor: AppColors.green,
+            tabs: [
+              Tab(text: 'All Activity'),
+              Tab(text: 'My Activity'),
+            ],
+          ),
+        ),
+        body: TabBarView(
+          children: [
+            _buildAllActivityTab(),
+            _buildMyActivityTab(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAllActivityTab() {
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text('Error loading activity: $_error',
+              textAlign: TextAlign.center),
+        ),
+      );
+    }
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_allItems.isEmpty) {
+      return const Center(child: Text('No activity yet.'));
+    }
+    return _buildList(_allItems);
+  }
+
+  Widget _buildMyActivityTab() {
+    final currentUser = FirebaseAuth.instance.currentUser;
+    if (currentUser == null || currentUser.isAnonymous) {
+      return _buildSignInPrompt();
+    }
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_myItems.isEmpty) {
+      return const Center(
+      child: Padding(
+        padding: EdgeInsets.all(24),
+        child: Text(
+          'None of your contributions have been approved yet.',
+          textAlign: TextAlign.center,
+          style: TextStyle(color: AppColors.gray),
+        ),
+      ),
+    );
+    }
+    return _buildList(_myItems);
+  }
+
+  Widget _buildSignInPrompt() {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.all(32.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            FaIcon(FontAwesomeIcons.user, size: 48, color: AppColors.gray),
+            SizedBox(height: 16),
+            Text(
+              'Sign in to see your activity',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: 8),
+            Text(
+              'Track your approved photos and data edits after signing in.',
+              style: TextStyle(color: AppColors.gray),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildList(List<ActivityItem> items) {
+    final features =
+        Provider.of<GeoJsonProvider>(context, listen: true).features;
+    final currentUser = FirebaseAuth.instance.currentUser;
+
+    return ListView.separated(
+      itemCount: items.length,
+      separatorBuilder: (_, __) => const Divider(height: 1, indent: 72),
+      itemBuilder: (context, index) {
+        final item = items[index];
+        final feature = _getFeature(item.spaceId, features);
+        final spaceName = feature?.properties.name ?? 'Unknown Space';
+        final borough = feature != null ? _boroughFromFeature(feature) : null;
+        final isCurrentUser =
+            currentUser != null && item.userId == currentUser.uid;
+        final who = isCurrentUser ? 'You' : item.username;
+        final action = item.type == 'photo' ? 'added a photo to' : 'updated data for';
+        final timeStr = timeago.format(item.timestamp);
+
+        return ListTile(
+          contentPadding:
+              const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          leading: CircleAvatar(
+            backgroundColor: item.type == 'photo'
+                ? AppColors.green.withValues(alpha: 0.15)
+                : AppColors.dark.withValues(alpha: 0.08),
+            child: FaIcon(
+              item.type == 'photo'
+                  ? FontAwesomeIcons.camera
+                  : FontAwesomeIcons.penToSquare,
+              color: item.type == 'photo' ? AppColors.green : AppColors.dark,
+              size: 16,
+            ),
+          ),
+          title: RichText(
+            text: TextSpan(
+              style: DefaultTextStyle.of(context).style.copyWith(fontSize: 14),
+              children: [
+                WidgetSpan(
+                  alignment: PlaceholderAlignment.middle,
+                  child: Padding(
+                    padding: const EdgeInsets.only(right: 4),
+                    child: FaIcon(FontAwesomeIcons.user,
+                        size: 11, color: AppColors.gray),
+                  ),
+                ),
+                TextSpan(
+                  text: who,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+                TextSpan(text: ' $action '),
+                WidgetSpan(
+                  alignment: PlaceholderAlignment.middle,
+                  child: Padding(
+                    padding: const EdgeInsets.only(right: 4),
+                    child: FaIcon(FontAwesomeIcons.locationDot,
+                        size: 11, color: AppColors.gray),
+                  ),
+                ),
+                TextSpan(
+                  text: spaceName,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+          ),
+          subtitle: Text(
+            borough != null ? '$timeStr · $borough' : timeStr,
+            style: const TextStyle(color: AppColors.gray, fontSize: 12),
+          ),
+          onTap: () => widget.onSpaceSelected(item.spaceId),
+        );
+      },
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'colors.dart';
 import 'map_screen.dart';
 import 'about_screen.dart';
 import 'profile_screen.dart';
+import 'activity_feed_screen.dart';
 import 'public_space_properties.dart';
 import 'user_provider.dart';
 import 'username_input_screen.dart';
@@ -175,6 +176,7 @@ class MyApp extends StatelessWidget {
 }
 
 final GlobalKey<_HomeScreenState> homeScreenKey = GlobalKey<_HomeScreenState>();
+final GlobalKey<MapScreenState> mapScreenKey = GlobalKey<MapScreenState>();
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -200,8 +202,9 @@ class _HomeScreenState extends State<HomeScreen> {
 
     // Initialize the list of pages with the feedback tap handler
     _pages = <Widget>[
-      MapScreen(onReportAnIssue: _handleReportAnIssue),
+      MapScreen(key: mapScreenKey, onReportAnIssue: _handleReportAnIssue),
       const AboutScreen(),
+      ActivityFeedScreen(onSpaceSelected: _selectSpaceOnMap),
       const ProfileScreen(),
     ];
   }
@@ -228,8 +231,21 @@ class _HomeScreenState extends State<HomeScreen> {
   void switchToMapTab() {
     print('switching to map tab');
     setState(() {
-      _selectedIndex = 0; // Index of the Profile tab
+      _selectedIndex = 0;
     });
+  }
+
+  void _selectSpaceOnMap(String spaceId) {
+    final features =
+        Provider.of<GeoJsonProvider>(context, listen: false).features;
+    try {
+      final feature =
+          features.firstWhere((f) => f.properties.firestoreId == spaceId);
+      // Call selectFeature before switching tabs so flyTo fires while the
+      // map controller is already warm (IndexedStack keeps it mounted).
+      mapScreenKey.currentState?.selectFeature(feature);
+    } catch (_) {}
+    setState(() => _selectedIndex = 0);
   }
 
   @override
@@ -255,27 +271,32 @@ class _HomeScreenState extends State<HomeScreen> {
           ),
           child: BottomNavigationBar(
             backgroundColor: Colors.white,
+            type: BottomNavigationBarType.fixed,
             items: const <BottomNavigationBarItem>[
               BottomNavigationBarItem(
                 icon: Padding(
-                  padding: EdgeInsets.only(
-                      top: 8.0, bottom: 4.0), // Add padding above the icon
+                  padding: EdgeInsets.only(top: 8.0, bottom: 4.0),
                   child: FaIcon(FontAwesomeIcons.map),
                 ),
                 label: 'Map',
               ),
               BottomNavigationBarItem(
                 icon: Padding(
-                  padding: EdgeInsets.only(
-                      top: 8.0, bottom: 4.0), // Add padding above the icon
+                  padding: EdgeInsets.only(top: 8.0, bottom: 4.0),
                   child: FaIcon(FontAwesomeIcons.circleInfo),
                 ),
                 label: 'About',
               ),
               BottomNavigationBarItem(
                 icon: Padding(
-                  padding: EdgeInsets.only(
-                      top: 8.0, bottom: 4.0), // Add padding above the icon
+                  padding: EdgeInsets.only(top: 8.0, bottom: 4.0),
+                  child: FaIcon(FontAwesomeIcons.clockRotateLeft),
+                ),
+                label: 'Activity',
+              ),
+              BottomNavigationBarItem(
+                icon: Padding(
+                  padding: EdgeInsets.only(top: 8.0, bottom: 4.0),
                   child: FaIcon(FontAwesomeIcons.user),
                 ),
                 label: 'Profile',

--- a/lib/map_screen.dart
+++ b/lib/map_screen.dart
@@ -54,29 +54,7 @@ class MapScreenState extends State<MapScreen> {
 
   void _onLocalResultSelected(PublicSpaceFeature? geojsonFeature) {
     if (geojsonFeature != null) {
-      // fly map to the selected feature, centered in the visible area between
-      // the search bar and the panel at its default 40% open height.
-      final geometry = geojsonFeature.geometry;
-      if (geometry != null) {
-        final mq = MediaQuery.of(context);
-        final double topInset = mq.viewPadding.top + 64; // safe area + search bar
-        final double bottomInset = mq.size.height * 0.40; // panel at 40%
-
-        mapboxMap?.flyTo(
-          CameraOptions(
-            zoom: 15,
-            center: Point.fromJson(geometry.toJson()),
-            padding: MbxEdgeInsets(
-              top: topInset,
-              right: 0,
-              bottom: bottomInset,
-              left: 0,
-            ),
-          ),
-          MapAnimationOptions(),
-        );
-      }
-
+      _flyToFeature(geojsonFeature);
       _onFeatureSelected(geojsonFeature);
     }
   }
@@ -196,6 +174,37 @@ class MapScreenState extends State<MapScreen> {
     } finally {
       if (mounted) _isAnimating = false;
     }
+  }
+
+  /// Called externally (e.g. from the activity feed) to select a space,
+  /// fly the map to it, and open the panel.
+  ///
+  /// Opens the panel immediately, then defers flyTo to a post-frame callback
+  /// so it fires only after the map tab is visible to the native renderer.
+  void selectFeature(PublicSpaceFeature feature) {
+    _onFeatureSelected(feature);
+    Future.delayed(const Duration(milliseconds: 400), () {
+      if (mounted) _flyToFeature(feature);
+    });
+  }
+
+  void _flyToFeature(PublicSpaceFeature feature) {
+    final mq = MediaQuery.of(context);
+    final double topInset = mq.viewPadding.top + 64;
+    final double bottomInset = mq.size.height * 0.40;
+    mapboxMap?.flyTo(
+      CameraOptions(
+        zoom: 15,
+        center: Point.fromJson(feature.geometry.toJson()),
+        padding: MbxEdgeInsets(
+          top: topInset,
+          right: 0,
+          bottom: bottomInset,
+          left: 0,
+        ),
+      ),
+      MapAnimationOptions(),
+    );
   }
 
   void _onFeatureSelected(dynamic geojsonFeature) {

--- a/lib/panel/panel_activity_section.dart
+++ b/lib/panel/panel_activity_section.dart
@@ -1,0 +1,204 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:timeago/timeago.dart' as timeago;
+
+import '../activity_feed_screen.dart';
+import '../colors.dart';
+import '../space_activity_screen.dart';
+
+class PanelActivitySection extends StatefulWidget {
+  final String spaceId;
+  final String spaceName;
+
+  const PanelActivitySection({
+    super.key,
+    required this.spaceId,
+    required this.spaceName,
+  });
+
+  @override
+  State<PanelActivitySection> createState() => _PanelActivitySectionState();
+}
+
+class _PanelActivitySectionState extends State<PanelActivitySection> {
+  List<ActivityItem> _items = [];
+  bool _loading = true;
+
+  StreamSubscription<QuerySnapshot>? _imagesSub;
+  StreamSubscription<QuerySnapshot>? _editsSub;
+  List<ActivityItem> _imageItems = [];
+  List<ActivityItem> _editItems = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribe();
+  }
+
+  @override
+  void didUpdateWidget(covariant PanelActivitySection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.spaceId != widget.spaceId) {
+      _imageItems = [];
+      _editItems = [];
+      setState(() => _loading = true);
+      _imagesSub?.cancel();
+      _editsSub?.cancel();
+      _subscribe();
+    }
+  }
+
+  @override
+  void dispose() {
+    _imagesSub?.cancel();
+    _editsSub?.cancel();
+    super.dispose();
+  }
+
+  void _subscribe() {
+    final db = FirebaseFirestore.instance;
+
+    _imagesSub = db
+        .collection('images')
+        .where('spaceId', isEqualTo: widget.spaceId)
+        .where('status', isEqualTo: 'approved')
+        .orderBy('timestamp', descending: true)
+        .snapshots()
+        .listen((snap) {
+      _imageItems = snap.docs.map((doc) {
+        final data = doc.data();
+        final ts = data['timestamp'] as Timestamp?;
+        return ActivityItem(
+          id: doc.id,
+          type: 'photo',
+          spaceId: data['spaceId'] as String? ?? '',
+          userId: data['userId'] as String? ?? '',
+          username: data['username'] as String? ?? 'someone',
+          timestamp: ts?.toDate() ?? DateTime.now(),
+        );
+      }).toList();
+      _rebuild();
+    });
+
+    _editsSub = db
+        .collection('public-spaces-edits')
+        .where('spaceId', isEqualTo: widget.spaceId)
+        .where('status', isEqualTo: 'approved')
+        .orderBy('timestamp', descending: true)
+        .snapshots()
+        .listen((snap) {
+      _editItems = snap.docs.map((doc) {
+        final data = doc.data();
+        final ts = data['timestamp'] as Timestamp?;
+        return ActivityItem(
+          id: doc.id,
+          type: 'edit',
+          spaceId: data['spaceId'] as String? ?? '',
+          userId: data['userId'] as String? ?? '',
+          username: data['userName'] as String? ?? 'someone',
+          timestamp: ts?.toDate() ?? DateTime.now(),
+        );
+      }).toList();
+      _rebuild();
+    });
+  }
+
+  void _rebuild() {
+    final merged = [..._imageItems, ..._editItems];
+    merged.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    setState(() {
+      _items = merged;
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 12),
+        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+      );
+    }
+
+    if (_items.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 8),
+        child: Text(
+          'No approved contributions yet.',
+          style: TextStyle(color: AppColors.gray, fontSize: 13),
+        ),
+      );
+    }
+
+    final preview = _items.take(5).toList();
+    final hasMore = _items.length > 5;
+    final currentUser = FirebaseAuth.instance.currentUser;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ...preview.map((item) => _buildRow(item, currentUser)),
+        if (hasMore || _items.length == 5)
+          Padding(
+            padding: const EdgeInsets.only(top: 6),
+            child: GestureDetector(
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => SpaceActivityScreen(
+                    spaceId: widget.spaceId,
+                    spaceName: widget.spaceName,
+                  ),
+                ),
+              ),
+              child: const Text(
+                'View all contributions →',
+                style: TextStyle(
+                  color: AppColors.green,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildRow(ActivityItem item, User? currentUser) {
+    final isMe = currentUser != null && item.userId == currentUser.uid;
+    final who = isMe ? 'You' : item.username;
+    final action = item.type == 'photo' ? 'added a photo' : 'updated data';
+    final timeStr = timeago.format(item.timestamp);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 2, right: 8),
+            child: FaIcon(
+              item.type == 'photo'
+                  ? FontAwesomeIcons.camera
+                  : FontAwesomeIcons.penToSquare,
+              size: 12,
+              color: AppColors.gray,
+            ),
+          ),
+          Expanded(
+            child: Text(
+              '$who $action · $timeStr',
+              style: const TextStyle(fontSize: 13, color: AppColors.dark),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/panel/panel_handler.dart
+++ b/lib/panel/panel_handler.dart
@@ -17,6 +17,7 @@ import 'panel_action_buttons.dart';
 import 'panel_location_section.dart';
 import 'panel_link_section.dart';
 import '../feedback_screen.dart';
+import 'panel_activity_section.dart';
 
 class PanelHandler extends StatefulWidget {
   final PublicSpaceFeature? selectedFeature;
@@ -73,7 +74,7 @@ class _PanelHandlerState extends State<PanelHandler> {
           .collection('images')
           .where('spaceId',
               isEqualTo: widget.selectedFeature!.properties.firestoreId)
-          .where('status', isNotEqualTo: 'rejected')
+          .where('status', isEqualTo: 'approved')
           .orderBy('timestamp', descending: false)
           .get();
 
@@ -242,6 +243,29 @@ class _PanelHandlerState extends State<PanelHandler> {
                             amenities: _panelContent!.properties.amenities,
                             equipment: _panelContent!.properties.equipment,
                             onEditTap: _handleEdit),
+                        const Divider(color: AppColors.gray, thickness: 0.5),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 8.0),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              const Text(
+                                'Recent Contributions',
+                                style: TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 14,
+                                ),
+                              ),
+                              const SizedBox(height: 8),
+                              PanelActivitySection(
+                                spaceId:
+                                    _panelContent!.properties.firestoreId,
+                                spaceName:
+                                    _panelContent!.properties.name ?? '',
+                              ),
+                            ],
+                          ),
+                        ),
                         const Divider(color: AppColors.gray, thickness: 0.5),
                         SizedBox(height: 10),
                         ElevatedButton(

--- a/lib/space_activity_screen.dart
+++ b/lib/space_activity_screen.dart
@@ -1,0 +1,197 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:timeago/timeago.dart' as timeago;
+
+import 'activity_feed_screen.dart';
+import 'colors.dart';
+
+class SpaceActivityScreen extends StatefulWidget {
+  final String spaceId;
+  final String spaceName;
+
+  const SpaceActivityScreen({
+    super.key,
+    required this.spaceId,
+    required this.spaceName,
+  });
+
+  @override
+  State<SpaceActivityScreen> createState() => _SpaceActivityScreenState();
+}
+
+class _SpaceActivityScreenState extends State<SpaceActivityScreen> {
+  List<ActivityItem> _items = [];
+  bool _loading = true;
+  String? _error;
+
+  StreamSubscription<QuerySnapshot>? _imagesSub;
+  StreamSubscription<QuerySnapshot>? _editsSub;
+  List<ActivityItem> _imageItems = [];
+  List<ActivityItem> _editItems = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _subscribe();
+  }
+
+  @override
+  void dispose() {
+    _imagesSub?.cancel();
+    _editsSub?.cancel();
+    super.dispose();
+  }
+
+  void _subscribe() {
+    final db = FirebaseFirestore.instance;
+
+    _imagesSub = db
+        .collection('images')
+        .where('spaceId', isEqualTo: widget.spaceId)
+        .where('status', isEqualTo: 'approved')
+        .orderBy('timestamp', descending: true)
+        .snapshots()
+        .listen(
+      (snap) {
+        _imageItems = snap.docs.map((doc) {
+          final data = doc.data();
+          final ts = data['timestamp'] as Timestamp?;
+          return ActivityItem(
+            id: doc.id,
+            type: 'photo',
+            spaceId: data['spaceId'] as String? ?? '',
+            userId: data['userId'] as String? ?? '',
+            username: data['username'] as String? ?? 'someone',
+            timestamp: ts?.toDate() ?? DateTime.now(),
+          );
+        }).toList();
+        _rebuild();
+      },
+      onError: (e) => setState(() => _error = e.toString()),
+    );
+
+    _editsSub = db
+        .collection('public-spaces-edits')
+        .where('spaceId', isEqualTo: widget.spaceId)
+        .where('status', isEqualTo: 'approved')
+        .orderBy('timestamp', descending: true)
+        .snapshots()
+        .listen(
+      (snap) {
+        _editItems = snap.docs.map((doc) {
+          final data = doc.data();
+          final ts = data['timestamp'] as Timestamp?;
+          return ActivityItem(
+            id: doc.id,
+            type: 'edit',
+            spaceId: data['spaceId'] as String? ?? '',
+            userId: data['userId'] as String? ?? '',
+            username: data['userName'] as String? ?? 'someone',
+            timestamp: ts?.toDate() ?? DateTime.now(),
+          );
+        }).toList();
+        _rebuild();
+      },
+      onError: (e) => setState(() => _error = e.toString()),
+    );
+  }
+
+  void _rebuild() {
+    final merged = [..._imageItems, ..._editItems];
+    merged.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    setState(() {
+      _items = merged;
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        surfaceTintColor: Colors.transparent,
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Contributions',
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+            Text(
+              widget.spaceName,
+              style: const TextStyle(fontSize: 12, color: AppColors.gray),
+            ),
+          ],
+        ),
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text('Error loading activity: $_error',
+              textAlign: TextAlign.center),
+        ),
+      );
+    }
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_items.isEmpty) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: Text(
+            'No approved contributions yet.',
+            style: TextStyle(color: AppColors.gray),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+
+    final currentUser = FirebaseAuth.instance.currentUser;
+
+    return ListView.separated(
+      itemCount: _items.length,
+      separatorBuilder: (_, __) => const Divider(height: 1, indent: 72),
+      itemBuilder: (context, index) {
+        final item = _items[index];
+        final isMe = currentUser != null && item.userId == currentUser.uid;
+        final who = isMe ? 'You' : item.username;
+        final action = item.type == 'photo'
+            ? 'added a photo'
+            : 'updated space data';
+        final timeStr = timeago.format(item.timestamp);
+
+        return ListTile(
+          contentPadding:
+              const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+          leading: CircleAvatar(
+            backgroundColor: item.type == 'photo'
+                ? AppColors.green.withValues(alpha: 0.15)
+                : AppColors.dark.withValues(alpha: 0.08),
+            child: FaIcon(
+              item.type == 'photo'
+                  ? FontAwesomeIcons.camera
+                  : FontAwesomeIcons.penToSquare,
+              color: item.type == 'photo' ? AppColors.green : AppColors.dark,
+              size: 16,
+            ),
+          ),
+          title: Text('$who $action',
+              style: const TextStyle(fontSize: 14)),
+          subtitle: Text(timeStr,
+              style: const TextStyle(color: AppColors.gray, fontSize: 12)),
+        );
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.7.2+13
+version: 1.7.3+14
 
 environment:
   sdk: ^3.5.1


### PR DESCRIPTION
## Summary

- Adds a new **Activity** tab (4th in bottom nav) with two sub-tabs: **All Activity** (all approved contributions app-wide) and **My Activity** (signed-in user's approved contributions; sign-in prompt for anonymous users)
- Each feed item shows bold username + bold space name with user/pin icons, borough derived from coordinates, and a relative timestamp subtitle
- Tapping a feed item switches to the Map tab and flies to + opens the panel for that space
- Space panel now includes a **Recent Contributions** section showing the latest 5 approved photos/edits, with a "View all contributions →" link opening a full-screen per-space activity screen
- Fixed `fetchImages` query to use `status == approved` (was broken for non-editors whenever any other user had a pending photo for the same space)

## Firestore requirements

Five new composite indexes are required — Firestore will log index-creation links on first query:

| Collection | Fields |
|---|---|
| `images` | `status ASC, timestamp DESC` |
| `images` | `spaceId ASC, status ASC, timestamp ASC` |
| `images` | `spaceId ASC, status ASC, timestamp DESC` |
| `public-spaces-edits` | `status ASC, timestamp DESC` |
| `public-spaces-edits` | `spaceId ASC, status ASC, timestamp DESC` |

Also requires a Firestore rule update on `public-spaces-edits` to allow reading approved docs:
```
allow read: if isEditor()
            || (request.auth != null && resource.data.userId == request.auth.uid)
            || resource.data.status == 'approved';
```

## Test plan

- [ ] Activity tab shows approved photos and edits with correct username, space name, borough, and relative time
- [ ] "My Activity" shows only the signed-in user's contributions; shows sign-in prompt when signed out
- [ ] Tapping a feed item opens the correct space panel and flies the map to it
- [ ] Space panel shows Recent Contributions section; "View all" opens full-screen list
- [ ] Photo gallery in panel loads correctly for spaces with approved images

🤖 Generated with [Claude Code](https://claude.com/claude-code)