### PR TITLE
Fix panel snap height and move Mapbox attribution to bottom right

### DIFF
--- a/lib/map_handler.dart
+++ b/lib/map_handler.dart
@@ -206,13 +206,13 @@ class _MapHandlerState extends State<MapHandler> {
     mapboxMap.scaleBar.updateSettings(ScaleBarSettings(enabled: false));
     mapboxMap.gestures.updateSettings(GesturesSettings(rotateEnabled: false));
 
-    // position logo and attribution
+    // position logo and attribution above the bottom info panel
     mapboxMap.logo
         .updateSettings(LogoSettings(marginBottom: 90, marginLeft: 15));
-    mapboxMap.attribution.updateSettings((AttributionSettings(
-        position: OrnamentPosition.BOTTOM_LEFT,
+    mapboxMap.attribution.updateSettings(AttributionSettings(
+        position: OrnamentPosition.BOTTOM_RIGHT,
         marginBottom: 90,
-        marginLeft: 110)));
+        marginRight: 10));
 
     // get location permission from the device
     var status = await Permission.locationWhenInUse.request();

--- a/lib/map_screen.dart
+++ b/lib/map_screen.dart
@@ -37,7 +37,7 @@ class MapScreenState extends State<MapScreen> {
   // Panel state
   bool _panelVisible = false;  // controls whether SlidingUpPanel is in the tree
   bool _panelExpanded = false; // true when panel is near max (for scrim)
-  double _maxPanelHeight = 600.0; // cached from LayoutBuilder, updated each build
+  double _snapPoint40 = 0.35; // cached snap position, updated each build
 
   // Map controls state
   bool _tracking = false;
@@ -224,9 +224,7 @@ class MapScreenState extends State<MapScreen> {
   }
 
   void _animatePanelToDefault() {
-    final screenHeight = MediaQuery.of(context).size.height;
-    final defaultPos = ((screenHeight * 0.40) - 106) / (_maxPanelHeight - 106);
-    _pc.animatePanelToPosition(defaultPos.clamp(0.0, 1.0));
+    _pc.animatePanelToPosition(_snapPoint40.clamp(0.0, 1.0));
   }
 
   void _closePanel() {
@@ -272,11 +270,10 @@ class MapScreenState extends State<MapScreen> {
     final double availableHeight = constraints.maxHeight;
     final double maxHeight = (availableHeight - mq.viewPadding.top - 8)
         .clamp(availableHeight * 0.85, availableHeight * 0.97);
-    _maxPanelHeight = maxHeight; // cache for _animatePanelToDefault
-
     // Intermediate snap at 40% of screen height (relative to min/max range)
     final double snapPoint40 =
         ((mq.size.height * 0.40) - 106) / (maxHeight - 106);
+    _snapPoint40 = snapPoint40; // cache so _animatePanelToDefault uses same value
 
     return Stack(
       children: <Widget>[


### PR DESCRIPTION
## Summary

- **Panel snap consistency**: `_animatePanelToDefault` previously recomputed the target position independently from the `snapPoint40` value the `SlidingUpPanel` was built with, causing search result taps to open the panel at a different height than map marker taps. Now `snapPoint40` is cached at build time and reused directly, so both code paths always snap to the same position.
- **Attribution control**: Moved the Mapbox attribution from bottom-left to bottom-right to reduce clutter near the Mapbox logo.

## Test plan

- [ ] Tapping a map marker opens the panel to ~40% screen height
- [ ] Tapping a search result opens the panel to the same height
- [ ] Mapbox attribution appears bottom-right, logo remains bottom-left

🤖 Generated with [Claude Code](https://claude.com/claude-code)