### PR TITLE
Add favorites feature with Firestore sync and GeoJSON map layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ ACCESS_TOKEN=pk.your_mapbox_access_token_here
    - Add `GoogleService-Info.plist` to `ios/Runner/`
 
 
+## Run on simulator/emulator
+
+`source .env && flutter run --dart-define=ACCESS_TOKEN=$ACCESS_TOKEN`
 
 ## Run on simulator/emulator
 

--- a/lib/favorites_provider.dart
+++ b/lib/favorites_provider.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'public_space_properties.dart';
+
+class FavoriteItem {
+  final String firestoreId;
+  final String name;
+  final String type;
+  final double lat;
+  final double lng;
+
+  const FavoriteItem({
+    required this.firestoreId,
+    required this.name,
+    required this.type,
+    required this.lat,
+    required this.lng,
+  });
+
+  factory FavoriteItem.fromFeature(PublicSpaceFeature feature) {
+    return FavoriteItem(
+      firestoreId: feature.properties.firestoreId,
+      name: feature.properties.name ?? '',
+      type: feature.properties.type,
+      lat: feature.geometry.coordinates.lat.toDouble(),
+      lng: feature.geometry.coordinates.lng.toDouble(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'firestoreId': firestoreId,
+        'name': name,
+        'type': type,
+        'lat': lat,
+        'lng': lng,
+      };
+
+  factory FavoriteItem.fromJson(Map<String, dynamic> json) => FavoriteItem(
+        firestoreId: json['firestoreId'] as String,
+        name: json['name'] as String,
+        type: json['type'] as String,
+        lat: (json['lat'] as num).toDouble(),
+        lng: (json['lng'] as num).toDouble(),
+      );
+}
+
+class FavoritesProvider extends ChangeNotifier {
+  static const _prefsKey = 'favorites_v1';
+  List<FavoriteItem> _favorites = [];
+
+  List<FavoriteItem> get favorites => List.unmodifiable(_favorites);
+  List<String> get favoriteIds =>
+      _favorites.map((f) => f.firestoreId).toList();
+
+  bool isFavorite(String firestoreId) =>
+      _favorites.any((f) => f.firestoreId == firestoreId);
+
+  Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonStr = prefs.getString(_prefsKey);
+    if (jsonStr != null) {
+      final list = jsonDecode(jsonStr) as List;
+      _favorites = list
+          .map((e) => FavoriteItem.fromJson(e as Map<String, dynamic>))
+          .toList();
+      notifyListeners();
+    }
+  }
+
+  Future<void> toggle(PublicSpaceFeature feature) async {
+    final id = feature.properties.firestoreId;
+    if (isFavorite(id)) {
+      _favorites.removeWhere((f) => f.firestoreId == id);
+    } else {
+      _favorites.add(FavoriteItem.fromFeature(feature));
+    }
+    notifyListeners();
+    await _persist();
+  }
+
+  Future<void> remove(String firestoreId) async {
+    _favorites.removeWhere((f) => f.firestoreId == firestoreId);
+    notifyListeners();
+    await _persist();
+  }
+
+  Future<void> _persist() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _prefsKey,
+      jsonEncode(_favorites.map((f) => f.toJson()).toList()),
+    );
+  }
+}

--- a/lib/favorites_provider.dart
+++ b/lib/favorites_provider.dart
@@ -1,6 +1,6 @@
-import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'public_space_properties.dart';
 
 class FavoriteItem {
@@ -17,6 +17,15 @@ class FavoriteItem {
     required this.lat,
     required this.lng,
   });
+
+  String? get borough {
+    if (lat >= 40.4774 && lat <= 40.6501 && lng >= -74.2591 && lng <= -74.0341) return 'Staten Island';
+    if (lat >= 40.6999 && lat <= 40.8816 && lng >= -74.0479 && lng <= -73.9067) return 'Manhattan';
+    if (lat >= 40.7855 && lat <= 40.9176 && lng >= -73.9339 && lng <= -73.7654) return 'Bronx';
+    if (lat >= 40.5707 && lat <= 40.7395 && lng >= -74.0421 && lng <= -73.8333) return 'Brooklyn';
+    if (lat >= 40.5431 && lat <= 40.8007 && lng >= -73.9625 && lng <= -73.7004) return 'Queens';
+    return null;
+  }
 
   factory FavoriteItem.fromFeature(PublicSpaceFeature feature) {
     return FavoriteItem(
@@ -46,7 +55,6 @@ class FavoriteItem {
 }
 
 class FavoritesProvider extends ChangeNotifier {
-  static const _prefsKey = 'favorites_v1';
   List<FavoriteItem> _favorites = [];
 
   List<FavoriteItem> get favorites => List.unmodifiable(_favorites);
@@ -56,40 +64,54 @@ class FavoritesProvider extends ChangeNotifier {
   bool isFavorite(String firestoreId) =>
       _favorites.any((f) => f.firestoreId == firestoreId);
 
-  Future<void> load() async {
-    final prefs = await SharedPreferences.getInstance();
-    final jsonStr = prefs.getString(_prefsKey);
-    if (jsonStr != null) {
-      final list = jsonDecode(jsonStr) as List;
-      _favorites = list
-          .map((e) => FavoriteItem.fromJson(e as Map<String, dynamic>))
-          .toList();
-      notifyListeners();
-    }
+  CollectionReference<Map<String, dynamic>>? _favoritesCollection(String uid) =>
+      FirebaseFirestore.instance
+          .collection('users')
+          .doc(uid)
+          .collection('favorites');
+
+  void initialize() {
+    FirebaseAuth.instance.authStateChanges().listen((user) async {
+      if (user != null) {
+        await _load(user.uid);
+      } else {
+        _favorites = [];
+        notifyListeners();
+      }
+    });
+  }
+
+  Future<void> _load(String uid) async {
+    final snapshot = await _favoritesCollection(uid)!.get();
+    _favorites = snapshot.docs
+        .map((doc) => FavoriteItem.fromJson(doc.data()))
+        .toList();
+    notifyListeners();
   }
 
   Future<void> toggle(PublicSpaceFeature feature) async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+
     final id = feature.properties.firestoreId;
     if (isFavorite(id)) {
       _favorites.removeWhere((f) => f.firestoreId == id);
+      notifyListeners();
+      await _favoritesCollection(user.uid)!.doc(id).delete();
     } else {
-      _favorites.add(FavoriteItem.fromFeature(feature));
+      final item = FavoriteItem.fromFeature(feature);
+      _favorites.add(item);
+      notifyListeners();
+      await _favoritesCollection(user.uid)!.doc(id).set(item.toJson());
     }
-    notifyListeners();
-    await _persist();
   }
 
   Future<void> remove(String firestoreId) async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+
     _favorites.removeWhere((f) => f.firestoreId == firestoreId);
     notifyListeners();
-    await _persist();
-  }
-
-  Future<void> _persist() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(
-      _prefsKey,
-      jsonEncode(_favorites.map((f) => f.toJson()).toList()),
-    );
+    await _favoritesCollection(user.uid)!.doc(firestoreId).delete();
   }
 }

--- a/lib/favorites_screen.dart
+++ b/lib/favorites_screen.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import 'favorites_provider.dart';
+import 'colors.dart';
+
+class FavoritesScreen extends StatelessWidget {
+  final void Function(FavoriteItem) onFavoriteTap;
+
+  const FavoritesScreen({super.key, required this.onFavoriteTap});
+
+  Color _typeColor(String type) {
+    switch (type) {
+      case 'park':
+        return AppColors.parkColor;
+      case 'wpaa':
+        return AppColors.wpaaColor;
+      case 'pops':
+        return AppColors.popsColor;
+      case 'plaza':
+        return AppColors.plazaColor;
+      case 'stp':
+        return AppColors.stpColor;
+      default:
+        return AppColors.miscColor;
+    }
+  }
+
+  String _typeLabel(String type) {
+    switch (type) {
+      case 'park':
+        return 'Park';
+      case 'wpaa':
+        return 'Waterfront Public Access Area';
+      case 'pops':
+        return 'Privately Owned Public Space';
+      case 'plaza':
+        return 'Street Plaza';
+      case 'stp':
+        return 'Schoolyards to Playgrounds';
+      default:
+        return 'Miscellaneous';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Favorites'),
+        backgroundColor: Colors.white,
+        foregroundColor: AppColors.dark,
+        elevation: 0,
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(0.5),
+          child: Container(color: Colors.grey.shade300, height: 0.5),
+        ),
+      ),
+      backgroundColor: AppColors.pageBackground,
+      body: Consumer<FavoritesProvider>(
+        builder: (context, provider, _) {
+          final favorites = provider.favorites;
+
+          if (favorites.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  FaIcon(
+                    FontAwesomeIcons.heart,
+                    size: 48,
+                    color: Colors.grey[300],
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'No favorites yet',
+                    style: TextStyle(
+                      fontSize: 18,
+                      color: Colors.grey[500],
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Tap the heart button on a space to save it here',
+                    style: TextStyle(fontSize: 13, color: Colors.grey[400]),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
+            );
+          }
+
+          return ListView.separated(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            itemCount: favorites.length,
+            separatorBuilder: (_, __) =>
+                const Divider(height: 0, indent: 16, endIndent: 16),
+            itemBuilder: (context, index) {
+              final item = favorites[index];
+              return _FavoriteListItem(
+                item: item,
+                typeColor: _typeColor(item.type),
+                typeLabel: _typeLabel(item.type),
+                onTap: () => onFavoriteTap(item),
+                onDelete: () => provider.remove(item.firestoreId),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _FavoriteListItem extends StatelessWidget {
+  final FavoriteItem item;
+  final Color typeColor;
+  final String typeLabel;
+  final VoidCallback onTap;
+  final VoidCallback onDelete;
+
+  const _FavoriteListItem({
+    required this.item,
+    required this.typeColor,
+    required this.typeLabel,
+    required this.onTap,
+    required this.onDelete,
+  });
+
+  Future<bool?> _confirmDismiss(BuildContext context) {
+    return showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Remove favorite?'),
+        content: Text('Remove "${item.name}" from your favorites?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: const Text('Remove'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      key: Key(item.firestoreId),
+      direction: DismissDirection.horizontal,
+      confirmDismiss: (_) => _confirmDismiss(context),
+      onDismissed: (_) => onDelete(),
+      background: Container(
+        color: Colors.red.shade400,
+        alignment: Alignment.centerLeft,
+        padding: const EdgeInsets.only(left: 20),
+        child: const FaIcon(FontAwesomeIcons.trash, color: Colors.white, size: 18),
+      ),
+      secondaryBackground: Container(
+        color: Colors.red.shade400,
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 20),
+        child: const FaIcon(FontAwesomeIcons.trash, color: Colors.white, size: 18),
+      ),
+      child: ListTile(
+        tileColor: Colors.white,
+        onTap: onTap,
+        leading: Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: typeColor.withValues(alpha: 0.15),
+            shape: BoxShape.circle,
+          ),
+          child: Center(
+            child: Container(
+              width: 12,
+              height: 12,
+              decoration: BoxDecoration(
+                color: typeColor,
+                shape: BoxShape.circle,
+              ),
+            ),
+          ),
+        ),
+        title: Text(
+          item.name.isNotEmpty ? item.name : 'Unnamed space',
+          style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 15),
+        ),
+        subtitle: Text(
+          typeLabel,
+          style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+        ),
+        trailing: const FaIcon(
+          FontAwesomeIcons.locationArrow,
+          size: 14,
+          color: AppColors.gray,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/favorites_screen.dart
+++ b/lib/favorites_screen.dart
@@ -195,14 +195,10 @@ class _FavoriteListItem extends StatelessWidget {
           style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 15),
         ),
         subtitle: Text(
-          typeLabel,
+          item.borough != null ? '$typeLabel · ${item.borough}' : typeLabel,
           style: TextStyle(fontSize: 12, color: Colors.grey[600]),
         ),
-        trailing: const FaIcon(
-          FontAwesomeIcons.locationArrow,
-          size: 14,
-          color: AppColors.gray,
-        ),
+        trailing: null,
       ),
     );
   }

--- a/lib/geojson_provider.dart
+++ b/lib/geojson_provider.dart
@@ -11,7 +11,7 @@ class GeoJsonProvider with ChangeNotifier {
   List<PublicSpaceFeature> get features => _features;
 
   Future<void> fetchGeoJson() async {
-    final url = Uri.parse('https://getdatasetasgeojson-vs6e5w5f2a-uc.a.run.app/');
+    final url = Uri.parse('https://getdatasetasgeojson-vs6e5w5f2a-uc.a.run.app/?slim=true');
     final response = await http.get(url);
     if (response.statusCode == 200) {
       final data = json.decode(response.body);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,8 @@ import 'public_space_properties.dart';
 import 'user_provider.dart';
 import 'username_input_screen.dart';
 import 'geojson_provider.dart';
+import 'favorites_provider.dart';
+import 'favorites_screen.dart';
 
 Future<void> initDynamicLinks(BuildContext context) async {
   print('Initializing dynamic links...');
@@ -125,6 +127,13 @@ void main() {
               return geoJsonProvider;
             },
           ),
+          ChangeNotifierProvider(
+            create: (_) {
+              final favoritesProvider = FavoritesProvider();
+              favoritesProvider.load();
+              return favoritesProvider;
+            },
+          ),
         ],
         child: const MyApp(),
       ),
@@ -203,6 +212,7 @@ class _HomeScreenState extends State<HomeScreen> {
     // Initialize the list of pages with the feedback tap handler
     _pages = <Widget>[
       MapScreen(key: mapScreenKey, onReportAnIssue: _handleReportAnIssue),
+      FavoritesScreen(onFavoriteTap: _handleFavoriteTap),
       const AboutScreen(),
       ActivityFeedScreen(onSpaceSelected: _selectSpaceOnMap),
       const ProfileScreen(),
@@ -225,6 +235,14 @@ class _HomeScreenState extends State<HomeScreen> {
     _scaffoldKey.currentState?.openDrawer();
     setState(() {
       _selectedFeature = selectedFeature;
+    });
+  }
+
+  void _handleFavoriteTap(FavoriteItem item) {
+    setState(() => _selectedIndex = 0);
+    // Wait one frame for the map tab to be active before flying
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      mapScreenKey.currentState?.flyToFavorite(item);
     });
   }
 
@@ -259,21 +277,24 @@ class _HomeScreenState extends State<HomeScreen> {
           index: _selectedIndex, // Display the selected tab
           children: _pages, // Keep all pages mounted
         ),
-        bottomNavigationBar: Container(
+        bottomNavigationBar: Consumer<FavoritesProvider>(
+          builder: (context, favProvider, _) {
+            final favCount = favProvider.favorites.length;
+            return Container(
           decoration: BoxDecoration(
-            color: Colors.white, // Background color of the BottomNavigationBar
+            color: Colors.white,
             border: Border(
               top: BorderSide(
-                color: Colors.grey.shade300, // Subtle gray border
-                width: 0.5, // Thickness of the border
+                color: Colors.grey.shade300,
+                width: 0.5,
               ),
             ),
           ),
           child: BottomNavigationBar(
-            backgroundColor: Colors.white,
             type: BottomNavigationBarType.fixed,
-            items: const <BottomNavigationBarItem>[
-              BottomNavigationBarItem(
+            backgroundColor: Colors.white,
+            items: <BottomNavigationBarItem>[
+              const BottomNavigationBarItem(
                 icon: Padding(
                   padding: EdgeInsets.only(top: 8.0, bottom: 4.0),
                   child: FaIcon(FontAwesomeIcons.map),
@@ -282,12 +303,24 @@ class _HomeScreenState extends State<HomeScreen> {
               ),
               BottomNavigationBarItem(
                 icon: Padding(
+                  padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
+                  child: Badge(
+                    isLabelVisible: favCount > 0,
+                    backgroundColor: AppColors.dark,
+                    label: Text('$favCount'),
+                    child: const FaIcon(FontAwesomeIcons.heart),
+                  ),
+                ),
+                label: 'Favorites',
+              ),
+              const BottomNavigationBarItem(
+                icon: Padding(
                   padding: EdgeInsets.only(top: 8.0, bottom: 4.0),
                   child: FaIcon(FontAwesomeIcons.circleInfo),
                 ),
                 label: 'About',
               ),
-              BottomNavigationBarItem(
+              const BottomNavigationBarItem(
                 icon: Padding(
                   padding: EdgeInsets.only(top: 8.0, bottom: 4.0),
                   child: FaIcon(FontAwesomeIcons.clockRotateLeft),
@@ -308,9 +341,12 @@ class _HomeScreenState extends State<HomeScreen> {
                 const TextStyle(fontSize: 10), // Adjust font size
             unselectedItemColor: AppColors.gray,
             unselectedLabelStyle: const TextStyle(fontSize: 10),
-            iconSize: 20, // Set the desired size for the icons
+            iconSize: 20,
             onTap: _onItemTapped,
           ),
-        ));
+        );
+          },
+        ),
+    );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -130,7 +130,7 @@ void main() {
           ChangeNotifierProvider(
             create: (_) {
               final favoritesProvider = FavoritesProvider();
-              favoritesProvider.load();
+              favoritesProvider.initialize();
               return favoritesProvider;
             },
           ),
@@ -240,10 +240,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
   void _handleFavoriteTap(FavoriteItem item) {
     setState(() => _selectedIndex = 0);
-    // Wait one frame for the map tab to be active before flying
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      mapScreenKey.currentState?.flyToFavorite(item);
-    });
+    mapScreenKey.currentState?.flyToFavorite(item);
   }
 
   void switchToMapTab() {

--- a/lib/map_handler.dart
+++ b/lib/map_handler.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -60,6 +61,7 @@ class MapHandler extends StatefulWidget {
   final Feature? markerFeature;
   final void Function(CameraChangedEventData)? onCameraChangeListener;
   final List<FavoriteItem> favorites;
+  final List<PublicSpaceFeature> features;
 
   const MapHandler(
       {super.key,
@@ -74,7 +76,8 @@ class MapHandler extends StatefulWidget {
       required this.miscImage,
       required this.markerFeature,
       this.onCameraChangeListener,
-      this.favorites = const []});
+      this.favorites = const [],
+      this.features = const []});
 
   @override
   _MapHandlerState createState() => _MapHandlerState();
@@ -82,7 +85,6 @@ class MapHandler extends StatefulWidget {
 
 class _MapHandlerState extends State<MapHandler> {
   late MapboxMap mapboxMap;
-  PointAnnotationManager? pointAnnotationManager;
   PointAnnotationManager? markerPointAnnotationManager;
   PointAnnotationManager? heartAnnotationManager;
   PointAnnotationManager? heartSelectedAnnotationManager;
@@ -90,11 +92,43 @@ class _MapHandlerState extends State<MapHandler> {
   Uint8List? _iconBytes;
   Uint8List? _heartBadgeBytes;
 
+  double _heartOpacity = 0.0; // hidden until zoom >= 13
+  Timer? _zoomDebounceTimer;
+  bool _sourceAdded = false;
+
   @override
   void initState() {
     super.initState();
     _loadFontAwesomeIcon();
     _loadHeartBadge();
+  }
+
+  @override
+  void dispose() {
+    _zoomDebounceTimer?.cancel();
+    super.dispose();
+  }
+
+  void _handleCameraChange(CameraChangedEventData event) {
+    widget.onCameraChangeListener?.call(event);
+
+    _zoomDebounceTimer?.cancel();
+    _zoomDebounceTimer = Timer(const Duration(milliseconds: 50), () async {
+      if (!mounted) return;
+      final state = await mapboxMap.getCameraState();
+      if (!mounted) return;
+      final zoom = state.zoom;
+      final newOpacity = zoom < 13.1
+          ? 0.0
+          : zoom > 13.2
+              ? 1.0
+              : (zoom - 13.0) / 0.1;
+      if ((newOpacity - _heartOpacity).abs() > 0.02) {
+        _heartOpacity = newOpacity;
+        await _updateHeartAnnotations();
+        await _updateSelectedHeartAnnotation();
+      }
+    });
   }
 
   Future<void> _loadFontAwesomeIcon() async {
@@ -171,6 +205,7 @@ class _MapHandlerState extends State<MapHandler> {
         iconSize: 1.0,
         iconAnchor: IconAnchor.BOTTOM,
         iconOffset: [10.0, -23.0],
+        iconOpacity: _heartOpacity,
       ));
     }
   }
@@ -190,7 +225,8 @@ class _MapHandlerState extends State<MapHandler> {
       image: _heartBadgeBytes,
       iconSize: 1.5,
       iconAnchor: IconAnchor.BOTTOM,
-      iconOffset: [15.0, -35.0],
+      iconOffset: [9.0, -24.0],
+      iconOpacity: 1.0,
     ));
   }
 
@@ -200,9 +236,19 @@ class _MapHandlerState extends State<MapHandler> {
     super.didUpdateWidget(oldWidget);
 
     if (widget.selectedFeature != oldWidget.selectedFeature) {
-      _updateAnnotations(widget.selectedFeature);
-      _updateHeartAnnotations();       // re-exclude/include the newly selected id
-      _updateSelectedHeartAnnotation(); // show/hide scaled badge on selected marker
+      _updateSelectedLayer(widget.selectedFeature?.properties.firestoreId);
+      _updateHeartAnnotations();
+      _updateSelectedHeartAnnotation();
+    }
+
+    final oldFeatureCount = oldWidget.features.length;
+    final newFeatureCount = widget.features.length;
+    if (oldFeatureCount != newFeatureCount && widget.features.isNotEmpty) {
+      if (!_sourceAdded) {
+        _addSpaceSourceAndLayers(widget.features);
+      } else {
+        _updateSpaceSourceData(widget.features);
+      }
     }
 
     final oldIds = oldWidget.favorites.map((f) => f.firestoreId).toSet();
@@ -250,44 +296,188 @@ class _MapHandlerState extends State<MapHandler> {
     }
   }
 
-  // Method to add annotation for the active feature
-  void _updateAnnotations(PublicSpaceFeature? feature) async {
-    // Clear any existing annotations
-    pointAnnotationManager?.deleteAll();
-    if (feature == null) {
-      return; // Exit early if feature is null
-    }
+  void _updateSelectedLayer(String? firestoreId) {
+    if (!_sourceAdded) return;
+    final filter = firestoreId != null
+        ? ['==', ['get', 'firestoreId'], firestoreId]
+        : ['==', ['get', 'firestoreId'], ''];
+    mapboxMap.style.setStyleLayerProperty(
+      'spaces-selected',
+      'filter',
+      jsonEncode(filter),
+    );
+  }
 
-    // Ensure pointAnnotationManager is ready
-    if (pointAnnotationManager != null) {
-      // Select image based on the feature type
-      Uint8List selectedImage;
-      if (feature.properties.type == 'park') {
-        selectedImage = widget.parkImage;
-      } else if (feature.properties.type == 'wpaa') {
-        selectedImage = widget.wpaaImage;
-      } else if (feature.properties.type == 'pops') {
-        selectedImage = widget.popsImage;
-      } else if (feature.properties.type == 'plaza') {
-        selectedImage = widget.plazaImage;
-      } else if (feature.properties.type == 'stp') {
-        selectedImage = widget.stpImage;
-      } else {
-        selectedImage = widget.miscImage; // Fallback to an empty image
+  Future<void> _addStyleImages() async {
+    final images = {
+      'park':  widget.parkImage,
+      'wpaa':  widget.wpaaImage,
+      'pops':  widget.popsImage,
+      'plaza': widget.plazaImage,
+      'stp':   widget.stpImage,
+      'misc':  widget.miscImage,
+    };
+
+    for (final entry in images.entries) {
+      try {
+        final codec = await ui.instantiateImageCodec(entry.value);
+        final frame = await codec.getNextFrame();
+        final image = frame.image;
+        final byteData = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+        if (byteData == null) {
+          print('addStyleImage: null byteData for ${entry.key}');
+          continue;
+        }
+        print('addStyleImage ${entry.key}: ${image.width}x${image.height}, ${byteData.lengthInBytes} bytes');
+        await mapboxMap.style.addStyleImage(
+          entry.key,
+          1.0,
+          MbxImage(
+            width: image.width,
+            height: image.height,
+            data: byteData.buffer.asUint8List(),
+          ),
+          false, [], [], null,
+        );
+      } catch (e) {
+        print('addStyleImage error for ${entry.key}: $e');
       }
-
-      // Create annotation options
-      PointAnnotationOptions annotationOptions = PointAnnotationOptions(
-        geometry: feature
-            .geometry, // Assuming the feature has a geometry of type Point
-        iconSize: 1.5,
-        image: selectedImage,
-        iconAnchor: IconAnchor.BOTTOM,
-      );
-
-      // Add annotation to the map
-      pointAnnotationManager?.create(annotationOptions);
     }
+  }
+
+  Map<String, dynamic> _buildFeatureCollection(List<PublicSpaceFeature> features) {
+    return {
+      'type': 'FeatureCollection',
+      'features': features.map((f) {
+        final json = f.toJson();
+        json['id'] = f.properties.firestoreId; // required for feature state
+        return json;
+      }).toList(),
+    };
+  }
+
+  Future<void> _addSpaceSourceAndLayers(List<PublicSpaceFeature> features) async {
+    await _addStyleImages();
+
+    await mapboxMap.style.addSource(GeoJsonSource(
+      id: 'public-spaces',
+      data: jsonEncode(_buildFeatureCollection(features)),
+    ));
+
+    const iconImageExpr = [
+      'match', ['get', 'type'],
+      'park', 'park', 'wpaa', 'wpaa', 'pops', 'pops',
+      'plaza', 'plaza', 'stp', 'stp', 'misc',
+    ];
+
+    await mapboxMap.style.addStyleLayer(jsonEncode({
+      'id': 'spaces-layer',
+      'type': 'circle',
+      'source': 'public-spaces',
+      'paint': {
+        'circle-emissive-strength': 1,
+        'circle-color': ['match', ['get', 'type'],
+          'park',  '#77bb3f',
+          'wpaa',  '#0ad6f5',
+          'pops',  '#6b82d6',
+          'plaza', '#ffbf47',
+          'stp',   '#F55353',
+          '#CCCCCC',
+        ],
+        'circle-radius': ['interpolate', ['linear'], ['zoom'], 12, 3, 14, 8],
+        'circle-stroke-width': ['interpolate', ['linear'], ['zoom'], 10, 1, 13, 2],
+        'circle-stroke-color': '#ffffff',
+        'circle-opacity': ['interpolate', ['linear'], ['zoom'], 13, 1, 13.1, 0],
+        'circle-stroke-opacity': ['interpolate', ['linear'], ['zoom'], 13, 1, 13.1, 0],
+      },
+    }), null);
+
+    await mapboxMap.style.addStyleLayer(jsonEncode({
+      'id': 'spaces-marker',
+      'type': 'symbol',
+      'source': 'public-spaces',
+      'layout': {
+        'icon-image': iconImageExpr,
+        'icon-size': 0.3,
+        'icon-anchor': 'bottom',
+        'icon-allow-overlap': true,
+        'text-allow-overlap': true,
+        'text-size': 12,
+        'text-offset': [0, -3],
+        'text-anchor': 'bottom',
+        'text-letter-spacing': 0.2,
+      },
+      'paint': {
+        'icon-opacity': ['interpolate', ['linear'], ['zoom'], 13, 0, 13.1, 1],
+        'text-halo-color': '#ffffff',
+        'text-halo-width': 1.4,
+        'text-opacity': ['interpolate', ['linear'], ['zoom'], 15, 0, 15.1, 1],
+        'text-color': '#2b2b2b',
+      },
+    }), null);
+
+    await mapboxMap.style.addStyleLayer(jsonEncode({
+      'id': 'spaces-label',
+      'type': 'symbol',
+      'source': 'public-spaces',
+      'layout': {
+        'icon-image': iconImageExpr,
+        'icon-size': 0.3,
+        'icon-anchor': 'bottom',
+        'icon-allow-overlap': true,
+        'text-field': ['to-string', ['get', 'name']],
+        'text-font': ['Poppins Regular', 'Arial Unicode MS Regular'],
+        'text-size': 12,
+        'text-offset': [0, -3],
+        'text-anchor': 'bottom',
+        'text-letter-spacing': 0.2,
+      },
+      'paint': {
+        'icon-opacity': ['interpolate', ['linear'], ['zoom'], 14, 0, 14.1, 1],
+        'text-halo-color': '#ffffff',
+        'text-halo-width': 1.4,
+        'text-opacity': ['interpolate', ['linear'], ['zoom'], 15, 0, 15.1, 1],
+        'text-color': '#2b2b2b',
+      },
+    }), null);
+
+    // Selected feature layer — filter updated dynamically on tap
+    await mapboxMap.style.addStyleLayer(jsonEncode({
+      'id': 'spaces-selected',
+      'type': 'symbol',
+      'source': 'public-spaces',
+      'filter': ['==', ['get', 'firestoreId'], ''],
+      'layout': {
+        'icon-image': iconImageExpr,
+        'icon-size': 0.45,
+        'icon-anchor': 'bottom',
+        'icon-allow-overlap': true,
+      },
+      'paint': {
+        'icon-opacity': 1.0,
+      },
+    }), null);
+
+    // Annotation managers created last so they render above all style layers
+    markerPointAnnotationManager =
+        await mapboxMap.annotations.createPointAnnotationManager();
+    heartAnnotationManager =
+        await mapboxMap.annotations.createPointAnnotationManager();
+    heartSelectedAnnotationManager =
+        await mapboxMap.annotations.createPointAnnotationManager();
+
+    _updateHeartAnnotations();
+    _updateSelectedHeartAnnotation();
+
+    _sourceAdded = true;
+  }
+
+  Future<void> _updateSpaceSourceData(List<PublicSpaceFeature> features) async {
+    await mapboxMap.style.setStyleSourceProperty(
+      'public-spaces',
+      'data',
+      jsonEncode(_buildFeatureCollection(features)),
+    );
   }
 
   _onMapCreated(MapboxMap mapboxMap) async {
@@ -336,23 +526,9 @@ class _MapHandlerState extends State<MapHandler> {
     // call onMapCreated callback to pass the map instance upward
     widget.onMapCreated(mapboxMap);
 
-    // Initialize PointAnnotationManagers (order matters for z-layering)
-    pointAnnotationManager =
-        await mapboxMap.annotations.createPointAnnotationManager();
-
-    markerPointAnnotationManager =
-        await mapboxMap.annotations.createPointAnnotationManager();
-
-    // Normal heart badges (non-selected favorites)
-    heartAnnotationManager =
-        await mapboxMap.annotations.createPointAnnotationManager();
-
-    // Scaled heart badge for the selected feature — created last so it's on top
-    heartSelectedAnnotationManager =
-        await mapboxMap.annotations.createPointAnnotationManager();
-
-    _updateHeartAnnotations();
-    _updateSelectedHeartAnnotation();
+    if (widget.features.isNotEmpty) {
+      await _addSpaceSourceAndLayers(widget.features);
+    }
   }
 
   _onMapTapListener(
@@ -366,20 +542,9 @@ class _MapHandlerState extends State<MapHandler> {
         .queryRenderedFeatures(
             RenderedQueryGeometry.fromScreenCoordinate(ScreenCoordinate(
                 x: context.touchPosition.x, y: context.touchPosition.y)),
-            RenderedQueryOptions(layerIds: [
-              'park-centroids',
-              'park-marker',
-              'wpaa-centroids',
-              'wpaa-marker',
-              'pops-centroids',
-              'pops-marker',
-              'plaza-centroids',
-              'plaza-marker',
-              'stp-centroids',
-              'stp-marker',
-              'misc-centroids',
-              'misc-marker'
-            ], filter: null))
+            RenderedQueryOptions(
+                layerIds: ['spaces-layer', 'spaces-marker', 'spaces-label'],
+                filter: null))
         .then((features) async {
       if (features.isNotEmpty) {
         // Parse the feature and call the parent callback
@@ -389,9 +554,6 @@ class _MapHandlerState extends State<MapHandler> {
 
         PublicSpaceFeature geojsonFeature =
             PublicSpaceFeature.fromJson(jsonDecode(geojsonFeatureString));
-
-        String firestoreId = geojsonFeature.properties.firestoreId;
-
 
         // Call parent callback to update the selectedFeature in parent state
         widget.onFeatureSelected(geojsonFeature);
@@ -417,13 +579,13 @@ class _MapHandlerState extends State<MapHandler> {
   @override
   Widget build(BuildContext context) {
     return MapWidget(
-      styleUri: 'mapbox://styles/chriswhongmapbox/clzu4xoh900oz01qsgnxq8sf1',
+      styleUri: 'mapbox://styles/chriswhongmapbox/cmpq8s9qs007401s76cfp5xmv',
       cameraOptions: CameraOptions(
         center: Point(coordinates: Position(-74.00299, 40.70966)),
         zoom: 12,
       ),
       onMapCreated: _onMapCreated,
-      onCameraChangeListener: widget.onCameraChangeListener,
+      onCameraChangeListener: _handleCameraChange,
       onTapListener: (MapContentGestureContext gestureContext) =>
           _onMapTapListener(context, gestureContext), // Pass context here,
     );

--- a/lib/map_handler.dart
+++ b/lib/map_handler.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:nyc_public_space_map/public_space_properties.dart';
 import 'package:geolocator/geolocator.dart' as geo;
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'favorites_provider.dart';
 
 Future<Uint8List> getFontAwesomeIconAsBytes({
   FaIconData icon = FontAwesomeIcons.mapMarkerAlt,
@@ -58,6 +59,7 @@ class MapHandler extends StatefulWidget {
   final Uint8List miscImage;
   final Feature? markerFeature;
   final void Function(CameraChangedEventData)? onCameraChangeListener;
+  final List<FavoriteItem> favorites;
 
   const MapHandler(
       {super.key,
@@ -71,7 +73,8 @@ class MapHandler extends StatefulWidget {
       required this.stpImage,
       required this.miscImage,
       required this.markerFeature,
-      this.onCameraChangeListener});
+      this.onCameraChangeListener,
+      this.favorites = const []});
 
   @override
   _MapHandlerState createState() => _MapHandlerState();
@@ -80,15 +83,18 @@ class MapHandler extends StatefulWidget {
 class _MapHandlerState extends State<MapHandler> {
   late MapboxMap mapboxMap;
   PointAnnotationManager? pointAnnotationManager;
-
   PointAnnotationManager? markerPointAnnotationManager;
+  PointAnnotationManager? heartAnnotationManager;
+  PointAnnotationManager? heartSelectedAnnotationManager;
+
   Uint8List? _iconBytes;
+  Uint8List? _heartBadgeBytes;
 
   @override
   void initState() {
     super.initState();
-
     _loadFontAwesomeIcon();
+    _loadHeartBadge();
   }
 
   Future<void> _loadFontAwesomeIcon() async {
@@ -97,10 +103,95 @@ class _MapHandlerState extends State<MapHandler> {
       size: 64,
       color: Colors.red,
     );
-
     setState(() {
       _iconBytes = bytes;
     });
+  }
+
+  Future<void> _loadHeartBadge() async {
+    const double size = 48;
+    const double iconSize = 26;
+
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+
+    // Filled circle background
+    canvas.drawCircle(
+      Offset(size / 2, size / 2),
+      size / 2,
+      Paint()..color = const Color(0xFFE53935),
+    );
+    // White border for contrast
+    canvas.drawCircle(
+      Offset(size / 2, size / 2),
+      size / 2 - 1.5,
+      Paint()
+        ..color = Colors.white
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 3,
+    );
+
+    // White heart icon centered in the circle
+    final textPainter = TextPainter(textDirection: TextDirection.ltr);
+    textPainter.text = TextSpan(
+      text: String.fromCharCode(FontAwesomeIcons.solidHeart.codePoint),
+      style: TextStyle(
+        fontSize: iconSize,
+        fontFamily: FontAwesomeIcons.solidHeart.fontFamily,
+        package: FontAwesomeIcons.solidHeart.fontPackage,
+        color: Colors.white,
+      ),
+    );
+    textPainter.layout();
+    textPainter.paint(
+      canvas,
+      Offset((size - textPainter.width) / 2, (size - textPainter.height) / 2),
+    );
+
+    final picture = recorder.endRecording();
+    final image = await picture.toImage(size.toInt(), size.toInt());
+    final bytes = await image.toByteData(format: ui.ImageByteFormat.png);
+
+    _heartBadgeBytes = bytes!.buffer.asUint8List();
+    // Re-draw badges now that the image is ready (favorites may already be set)
+    _updateHeartAnnotations();
+  }
+
+  // Normal-size heart badges for all favorited features except the selected one.
+  Future<void> _updateHeartAnnotations() async {
+    if (heartAnnotationManager == null || _heartBadgeBytes == null) return;
+    await heartAnnotationManager!.deleteAll();
+
+    final selectedId = widget.selectedFeature?.properties.firestoreId;
+    for (final item in widget.favorites) {
+      if (item.firestoreId == selectedId) continue; // handled by selected manager
+      await heartAnnotationManager!.create(PointAnnotationOptions(
+        geometry: Point(coordinates: Position(item.lng, item.lat)),
+        image: _heartBadgeBytes,
+        iconSize: 1.0,
+        iconAnchor: IconAnchor.BOTTOM,
+        iconOffset: [10.0, -23.0],
+      ));
+    }
+  }
+
+  // Scaled heart badge for the selected feature (matches 1.5× enlarged marker).
+  Future<void> _updateSelectedHeartAnnotation() async {
+    if (heartSelectedAnnotationManager == null || _heartBadgeBytes == null) return;
+    await heartSelectedAnnotationManager!.deleteAll();
+
+    final selected = widget.selectedFeature;
+    if (selected == null) return;
+    final isFav = widget.favorites.any((f) => f.firestoreId == selected.properties.firestoreId);
+    if (!isFav) return;
+
+    await heartSelectedAnnotationManager!.create(PointAnnotationOptions(
+      geometry: selected.geometry,
+      image: _heartBadgeBytes,
+      iconSize: 1.5,
+      iconAnchor: IconAnchor.BOTTOM,
+      iconOffset: [15.0, -35.0],
+    ));
   }
 
   // Detect changes in selectedFeature and update the map accordingly
@@ -110,6 +201,15 @@ class _MapHandlerState extends State<MapHandler> {
 
     if (widget.selectedFeature != oldWidget.selectedFeature) {
       _updateAnnotations(widget.selectedFeature);
+      _updateHeartAnnotations();       // re-exclude/include the newly selected id
+      _updateSelectedHeartAnnotation(); // show/hide scaled badge on selected marker
+    }
+
+    final oldIds = oldWidget.favorites.map((f) => f.firestoreId).toSet();
+    final newIds = widget.favorites.map((f) => f.firestoreId).toSet();
+    if (!oldIds.containsAll(newIds) || !newIds.containsAll(oldIds)) {
+      _updateHeartAnnotations();
+      _updateSelectedHeartAnnotation();
     }
 
     if (jsonEncode(widget.markerFeature?.toJson()) !=
@@ -236,12 +336,23 @@ class _MapHandlerState extends State<MapHandler> {
     // call onMapCreated callback to pass the map instance upward
     widget.onMapCreated(mapboxMap);
 
-    // Initialize PointAnnotationManager
+    // Initialize PointAnnotationManagers (order matters for z-layering)
     pointAnnotationManager =
         await mapboxMap.annotations.createPointAnnotationManager();
 
-    markerPointAnnotationManager = 
+    markerPointAnnotationManager =
         await mapboxMap.annotations.createPointAnnotationManager();
+
+    // Normal heart badges (non-selected favorites)
+    heartAnnotationManager =
+        await mapboxMap.annotations.createPointAnnotationManager();
+
+    // Scaled heart badge for the selected feature — created last so it's on top
+    heartSelectedAnnotationManager =
+        await mapboxMap.annotations.createPointAnnotationManager();
+
+    _updateHeartAnnotations();
+    _updateSelectedHeartAnnotation();
   }
 
   _onMapTapListener(

--- a/lib/map_screen.dart
+++ b/lib/map_screen.dart
@@ -5,15 +5,17 @@ import 'package:nyc_public_space_map/colors.dart';
 import 'package:sliding_up_panel/sliding_up_panel.dart';
 import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 import 'package:geolocator/geolocator.dart' as geo;
+import 'package:provider/provider.dart';
 
 import 'package:nyc_public_space_map/map_handler.dart';
 import 'package:nyc_public_space_map/panel/panel_handler.dart';
-// import 'package:nyc_public_space_map/search_handler.dart';
 import 'search_widget.dart';
 import 'package:nyc_public_space_map/image_loader.dart';
 import 'package:nyc_public_space_map/public_space_properties.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'widgets/map_controls.dart';
+import 'favorites_provider.dart';
+import 'geojson_provider.dart';
 
 class MapScreen extends StatefulWidget {
   final Function(PublicSpaceFeature?) onReportAnIssue;
@@ -227,6 +229,50 @@ class MapScreenState extends State<MapScreen> {
     _pc.animatePanelToPosition(_snapPoint40.clamp(0.0, 1.0));
   }
 
+  Future<void> flyToFavorite(FavoriteItem item) async {
+    if (mapboxMap == null) return;
+
+    // Look up full feature so the panel can open
+    final geoJsonProvider =
+        Provider.of<GeoJsonProvider>(context, listen: false);
+    PublicSpaceFeature? feature;
+    for (final f in geoJsonProvider.features) {
+      if (f.properties.firestoreId == item.firestoreId) {
+        feature = f;
+        break;
+      }
+    }
+
+    // Open the panel first so the padding used for flyTo matches the actual
+    // panel height that will be visible when the camera lands.
+    if (feature != null) {
+      _onFeatureSelected(feature);
+    }
+
+    // Fly with _isAnimating = true so the move listener doesn't collapse the panel.
+    final mq = MediaQuery.of(context);
+    _isAnimating = true;
+    try {
+      await mapboxMap!.flyTo(
+        CameraOptions(
+          center: feature != null
+              ? feature.geometry
+              : Point(coordinates: Position(item.lng, item.lat)),
+          zoom: 16,
+          padding: MbxEdgeInsets(
+            top: mq.viewPadding.top + 64,
+            right: 0,
+            bottom: mq.size.height * 0.40,
+            left: 0,
+          ),
+        ),
+        MapAnimationOptions(duration: 800),
+      );
+    } finally {
+      if (mounted) _isAnimating = false;
+    }
+  }
+
   void _closePanel() {
     setState(() {
       selectedFeature = null;
@@ -289,6 +335,7 @@ class MapScreenState extends State<MapScreen> {
           miscImage: ImageLoader.instance.miscImage,
           markerFeature: markerFeature,
           onCameraChangeListener: _onCameraChanged,
+          favorites: Provider.of<FavoritesProvider>(context).favorites,
         ),
         _buildBottomInfoPanel(),
         // Scrim — fades in when panel is fully expanded

--- a/lib/map_screen.dart
+++ b/lib/map_screen.dart
@@ -230,8 +230,6 @@ class MapScreenState extends State<MapScreen> {
   }
 
   Future<void> flyToFavorite(FavoriteItem item) async {
-    if (mapboxMap == null) return;
-
     // Look up full feature so the panel can open
     final geoJsonProvider =
         Provider.of<GeoJsonProvider>(context, listen: false);
@@ -243,13 +241,15 @@ class MapScreenState extends State<MapScreen> {
       }
     }
 
-    // Open the panel first so the padding used for flyTo matches the actual
-    // panel height that will be visible when the camera lands.
     if (feature != null) {
       _onFeatureSelected(feature);
     }
 
-    // Fly with _isAnimating = true so the move listener doesn't collapse the panel.
+    // Defer flyTo so the native map renderer is ready after the tab switch,
+    // same pattern as selectFeature.
+    await Future.delayed(const Duration(milliseconds: 400));
+    if (!mounted || mapboxMap == null) return;
+
     final mq = MediaQuery.of(context);
     _isAnimating = true;
     try {
@@ -336,6 +336,7 @@ class MapScreenState extends State<MapScreen> {
           markerFeature: markerFeature,
           onCameraChangeListener: _onCameraChanged,
           favorites: Provider.of<FavoritesProvider>(context).favorites,
+          features: Provider.of<GeoJsonProvider>(context).features,
         ),
         _buildBottomInfoPanel(),
         // Scrim — fades in when panel is fully expanded

--- a/lib/panel/panel_action_buttons.dart
+++ b/lib/panel/panel_action_buttons.dart
@@ -7,11 +7,15 @@ class PanelActionButtons extends StatelessWidget {
   final VoidCallback onOpenMaps;
   final VoidCallback onEdit;
   final VoidCallback onSubmitPhoto;
+  final VoidCallback onToggleFavorite;
+  final bool isFavorited;
 
   const PanelActionButtons({
     required this.onOpenMaps,
     required this.onEdit,
     required this.onSubmitPhoto,
+    required this.onToggleFavorite,
+    required this.isFavorited,
     super.key,
   });
 
@@ -19,7 +23,7 @@ class PanelActionButtons extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        SizedBox(height: 10),
+        const SizedBox(height: 10),
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
@@ -41,10 +45,50 @@ class PanelActionButtons extends StatelessWidget {
               tooltip: 'Submit a Photo',
               onPressed: onSubmitPhoto,
             ),
+            _FavoriteButton(
+              isFavorited: isFavorited,
+              onPressed: onToggleFavorite,
+            ),
           ],
         ),
-        
-        SizedBox(height: 10),
+        const SizedBox(height: 10),
+      ],
+    );
+  }
+}
+
+class _FavoriteButton extends StatelessWidget {
+  final bool isFavorited;
+  final VoidCallback onPressed;
+
+  const _FavoriteButton({required this.isFavorited, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          decoration: BoxDecoration(
+            color: isFavorited ? Colors.red.shade50 : Colors.grey[300],
+            shape: BoxShape.circle,
+          ),
+          child: IconButton(
+            icon: FaIcon(
+              isFavorited
+                  ? FontAwesomeIcons.solidHeart
+                  : FontAwesomeIcons.heart,
+              size: 20,
+              color: isFavorited ? Colors.red.shade400 : Colors.grey[800],
+            ),
+            onPressed: onPressed,
+            tooltip: isFavorited ? 'Remove from favorites' : 'Add to favorites',
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          isFavorited ? 'Favorited' : 'Favorite',
+          style: const TextStyle(fontSize: 12),
+        ),
       ],
     );
   }

--- a/lib/panel/panel_action_buttons.dart
+++ b/lib/panel/panel_action_buttons.dart
@@ -7,15 +7,11 @@ class PanelActionButtons extends StatelessWidget {
   final VoidCallback onOpenMaps;
   final VoidCallback onEdit;
   final VoidCallback onSubmitPhoto;
-  final VoidCallback onToggleFavorite;
-  final bool isFavorited;
 
   const PanelActionButtons({
     required this.onOpenMaps,
     required this.onEdit,
     required this.onSubmitPhoto,
-    required this.onToggleFavorite,
-    required this.isFavorited,
     super.key,
   });
 
@@ -45,10 +41,6 @@ class PanelActionButtons extends StatelessWidget {
               tooltip: 'Submit a Photo',
               onPressed: onSubmitPhoto,
             ),
-            _FavoriteButton(
-              isFavorited: isFavorited,
-              onPressed: onToggleFavorite,
-            ),
           ],
         ),
         const SizedBox(height: 10),
@@ -57,39 +49,3 @@ class PanelActionButtons extends StatelessWidget {
   }
 }
 
-class _FavoriteButton extends StatelessWidget {
-  final bool isFavorited;
-  final VoidCallback onPressed;
-
-  const _FavoriteButton({required this.isFavorited, required this.onPressed});
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Container(
-          decoration: BoxDecoration(
-            color: isFavorited ? Colors.red.shade50 : Colors.grey[300],
-            shape: BoxShape.circle,
-          ),
-          child: IconButton(
-            icon: FaIcon(
-              isFavorited
-                  ? FontAwesomeIcons.solidHeart
-                  : FontAwesomeIcons.heart,
-              size: 20,
-              color: isFavorited ? Colors.red.shade400 : Colors.grey[800],
-            ),
-            onPressed: onPressed,
-            tooltip: isFavorited ? 'Remove from favorites' : 'Add to favorites',
-          ),
-        ),
-        const SizedBox(height: 4),
-        Text(
-          isFavorited ? 'Favorited' : 'Favorite',
-          style: const TextStyle(fontSize: 12),
-        ),
-      ],
-    );
-  }
-}

--- a/lib/panel/panel_handler.dart
+++ b/lib/panel/panel_handler.dart
@@ -42,12 +42,23 @@ class _PanelHandlerState extends State<PanelHandler> {
   late PublicSpaceFeature? _panelContent;
   List<Map<String, dynamic>> imageList = [];
   bool _isLoading = true;
+  int _favoriteCount = 0;
+
+  // Fields fetched from Firestore (not in slim GeoJSON)
+  String? _fetchedDescription;
+  String? _fetchedLocation;
+  Uri? _fetchedUrl;
+  List<String> _fetchedDetails = [];
+  List<String> _fetchedAmenities = [];
+  List<String> _fetchedEquipment = [];
 
   @override
   void initState() {
     super.initState();
     _panelContent = widget.selectedFeature;
     fetchImages();
+    fetchFavoriteCount();
+    fetchSpaceDetails();
   }
 
   @override
@@ -58,8 +69,17 @@ class _PanelHandlerState extends State<PanelHandler> {
         _panelContent = widget.selectedFeature;
         _isLoading = true;
         imageList = [];
+        _favoriteCount = 0;
+        _fetchedDescription = null;
+        _fetchedLocation = null;
+        _fetchedUrl = null;
+        _fetchedDetails = [];
+        _fetchedAmenities = [];
+        _fetchedEquipment = [];
       });
       fetchImages();
+      fetchFavoriteCount();
+      fetchSpaceDetails();
     }
   }
 
@@ -112,6 +132,57 @@ class _PanelHandlerState extends State<PanelHandler> {
         _isLoading = false;
       });
     }
+  }
+
+  Future<void> fetchFavoriteCount() async {
+    final id = widget.selectedFeature?.properties.firestoreId;
+    if (id == null) return;
+    try {
+      final snapshot = await FirebaseFirestore.instance
+          .collectionGroup('favorites')
+          .where('firestoreId', isEqualTo: id)
+          .count()
+          .get();
+      if (mounted) {
+        setState(() {
+          _favoriteCount = snapshot.count ?? 0;
+        });
+      }
+    } catch (e) {
+      print('fetchFavoriteCount error: $e');
+    }
+  }
+
+  Future<void> fetchSpaceDetails() async {
+    final id = widget.selectedFeature?.properties.firestoreId;
+    if (id == null) return;
+    try {
+      final doc = await FirebaseFirestore.instance
+          .collection('public-spaces-main')
+          .doc(id)
+          .get();
+      if (!mounted || !doc.exists) return;
+      final data = doc.data()!;
+      setState(() {
+        _fetchedDescription = data['description'] as String?;
+        _fetchedLocation = data['location'] as String?;
+        final rawUrl = data['url'] as String?;
+        _fetchedUrl = (rawUrl != null && rawUrl.isNotEmpty)
+            ? Uri.tryParse(rawUrl)
+            : null;
+        _fetchedDetails = _toStringList(data['details']);
+        _fetchedAmenities = _toStringList(data['amenities']);
+        _fetchedEquipment = _toStringList(data['equipment']);
+      });
+    } catch (e) {
+      print('fetchSpaceDetails error: $e');
+    }
+  }
+
+  List<String> _toStringList(dynamic value) {
+    if (value == null) return [];
+    if (value is List) return List<String>.from(value);
+    return [];
   }
 
   Future<String> _getDownloadUrl(
@@ -198,9 +269,29 @@ class _PanelHandlerState extends State<PanelHandler> {
               children: [
                 Align(
                   alignment: Alignment.centerLeft,
-                  child: PanelHeader(
-                    name: _panelContent!.properties.name ?? '',
-                    type: _panelContent!.properties.type,
+                  child: Consumer<FavoritesProvider>(
+                    builder: (context, favProvider, _) {
+                      final isFav = favProvider
+                          .isFavorite(_panelContent!.properties.firestoreId);
+                      return PanelHeader(
+                        name: _panelContent!.properties.name ?? '',
+                        type: _panelContent!.properties.type,
+                        isFavorite: isFav,
+                        favoriteCount: _favoriteCount,
+                        onFavoriteTap: () {
+                          final user = FirebaseAuth.instance.currentUser;
+                          if (user == null) {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (context) => const SignInScreen()),
+                            );
+                          } else {
+                            favProvider.toggle(_panelContent!);
+                          }
+                        },
+                      );
+                    },
                   ),
                 ),
                 const Divider(color: AppColors.gray, thickness: 0.5),
@@ -211,11 +302,11 @@ class _PanelHandlerState extends State<PanelHandler> {
                         : const NeverScrollableScrollPhysics(),
                     child: Column(
                       children: [
-                        if (_panelContent!.properties.description?.isNotEmpty ==
+                        if ((_fetchedDescription ?? _panelContent!.properties.description)?.isNotEmpty ==
                             true)
                           Padding(
                             padding: const EdgeInsets.symmetric(vertical: 4.0),
-                            child: Text(_panelContent!.properties.description!),
+                            child: Text(_fetchedDescription ?? _panelContent!.properties.description!),
                           ),
                         const Divider(color: AppColors.gray, thickness: 0.5),
                         PanelImageGallery(
@@ -224,35 +315,27 @@ class _PanelHandlerState extends State<PanelHandler> {
                           onAddPhoto: _handleAddPhoto,
                         ),
                         const Divider(color: AppColors.gray, thickness: 0.5),
-                        Consumer<FavoritesProvider>(
-                          builder: (context, favProvider, _) {
-                            return PanelActionButtons(
-                              onOpenMaps: _handleOpenMaps,
-                              onEdit: _handleEdit,
-                              onSubmitPhoto: _handleAddPhoto,
-                              isFavorited: favProvider.isFavorite(
-                                  _panelContent!.properties.firestoreId),
-                              onToggleFavorite: () =>
-                                  favProvider.toggle(_panelContent!),
-                            );
-                          },
+                        PanelActionButtons(
+                          onOpenMaps: _handleOpenMaps,
+                          onEdit: _handleEdit,
+                          onSubmitPhoto: _handleAddPhoto,
                         ),
                         const Divider(color: AppColors.gray, thickness: 0.5),
                         PanelLocationSection(
-                          location: _panelContent!.properties.location,
+                          location: _fetchedLocation ?? _panelContent!.properties.location,
                           onTap: _handleOpenMaps,
                         ),
                         const Divider(color: AppColors.gray, thickness: 0.5),
                         PanelLinkSection(
-                          url: _panelContent!.properties.url,
+                          url: _fetchedUrl ?? _panelContent!.properties.url,
                           onTap: () =>
-                              launchUrl(_panelContent!.properties.url!),
+                              launchUrl((_fetchedUrl ?? _panelContent!.properties.url)!),
                         ),
                         const Divider(color: AppColors.gray, thickness: 0.5),
                         AttributeDisplay(
-                            details: _panelContent!.properties.details,
-                            amenities: _panelContent!.properties.amenities,
-                            equipment: _panelContent!.properties.equipment,
+                            details: _fetchedDetails.isNotEmpty ? _fetchedDetails : _panelContent!.properties.details,
+                            amenities: _fetchedAmenities.isNotEmpty ? _fetchedAmenities : _panelContent!.properties.amenities,
+                            equipment: _fetchedEquipment.isNotEmpty ? _fetchedEquipment : _panelContent!.properties.equipment,
                             onEditTap: _handleEdit),
                         const Divider(color: AppColors.gray, thickness: 0.5),
                         Padding(
@@ -316,7 +399,7 @@ class _PanelHandlerState extends State<PanelHandler> {
           ),
         ),
         Positioned(
-          right: 10,
+          right: 4,
           top: 10,
           child: IconButton(
             icon: const Icon(Icons.close, color: AppColors.dark),

--- a/lib/panel/panel_handler.dart
+++ b/lib/panel/panel_handler.dart
@@ -5,12 +5,15 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:url_launcher/url_launcher.dart'; // Import the url_launcher package
 
+import 'package:provider/provider.dart';
+
 import '../public_space_properties.dart';
 import '../submit_image.dart';
 import '../editor_screen.dart';
 import '../sign_in_screen.dart';
 import '../attribute_display.dart';
 import '../colors.dart';
+import '../favorites_provider.dart';
 import 'panel_header.dart';
 import 'panel_image_gallery.dart';
 import 'panel_action_buttons.dart';
@@ -221,10 +224,18 @@ class _PanelHandlerState extends State<PanelHandler> {
                           onAddPhoto: _handleAddPhoto,
                         ),
                         const Divider(color: AppColors.gray, thickness: 0.5),
-                        PanelActionButtons(
-                          onOpenMaps: _handleOpenMaps,
-                          onEdit: _handleEdit,
-                          onSubmitPhoto: _handleAddPhoto,
+                        Consumer<FavoritesProvider>(
+                          builder: (context, favProvider, _) {
+                            return PanelActionButtons(
+                              onOpenMaps: _handleOpenMaps,
+                              onEdit: _handleEdit,
+                              onSubmitPhoto: _handleAddPhoto,
+                              isFavorited: favProvider.isFavorite(
+                                  _panelContent!.properties.firestoreId),
+                              onToggleFavorite: () =>
+                                  favProvider.toggle(_panelContent!),
+                            );
+                          },
                         ),
                         const Divider(color: AppColors.gray, thickness: 0.5),
                         PanelLocationSection(

--- a/lib/panel/panel_header.dart
+++ b/lib/panel/panel_header.dart
@@ -4,10 +4,16 @@ import '../colors.dart';
 class PanelHeader extends StatelessWidget {
   final String name;
   final String type;
+  final bool isFavorite;
+  final VoidCallback onFavoriteTap;
+  final int favoriteCount;
 
   const PanelHeader({
     required this.name,
     required this.type,
+    required this.isFavorite,
+    required this.onFavoriteTap,
+    required this.favoriteCount,
     super.key,
   });
 
@@ -75,6 +81,26 @@ class PanelHeader extends StatelessWidget {
           typeLabel,
           style: const TextStyle(fontSize: 12),
         ),
+        const SizedBox(width: 8),
+        GestureDetector(
+          onTap: onFavoriteTap,
+          child: Icon(
+            isFavorite ? Icons.favorite : Icons.favorite_border,
+            size: 22,
+            color: isFavorite ? Colors.pink[300] : Colors.grey[400],
+          ),
+        ),
+        if (favoriteCount > 0) ...[
+          const SizedBox(width: 4),
+          Text(
+            '$favoriteCount',
+            style: TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.bold,
+              color: isFavorite ? Colors.pink[300] : Colors.grey[400],
+            ),
+          ),
+        ],
       ],
     );
   }

--- a/lib/public_space_properties.dart
+++ b/lib/public_space_properties.dart
@@ -4,7 +4,7 @@ import 'package:mapbox_maps_flutter/mapbox_maps_flutter.dart';
 
 class PublicSpaceProperties {
   final String firestoreId;
-  final String space_id;
+  final String? space_id;
   final String type;
   final String? name;
   final String? location;
@@ -17,7 +17,7 @@ class PublicSpaceProperties {
   // constructor to initialize the properties
   PublicSpaceProperties({
     required this.firestoreId,
-    required this.space_id,
+    this.space_id,
     required this.name,
     required this.type,
     required this.location,
@@ -106,15 +106,21 @@ class PublicSpaceFeature {
                 json['properties']['url'].isNotEmpty
             ? Uri.parse(json['properties']['url'])
             : null,
-        description: json['properties']['description'], // Parse the URL
+        description: json['properties']['description'],
 details: json['properties']['details'] != null
-    ? List<String>.from(jsonDecode(json['properties']['details']))
+    ? (json['properties']['details'] is String
+        ? List<String>.from(jsonDecode(json['properties']['details']))
+        : List<String>.from(json['properties']['details']))
     : [],
 amenities: json['properties']['amenities'] != null
-    ? List<String>.from(jsonDecode(json['properties']['amenities']))
+    ? (json['properties']['amenities'] is String
+        ? List<String>.from(jsonDecode(json['properties']['amenities']))
+        : List<String>.from(json['properties']['amenities']))
     : [],
 equipment: json['properties']['equipment'] != null
-    ? List<String>.from(jsonDecode(json['properties']['equipment']))
+    ? (json['properties']['equipment'] is String
+        ? List<String>.from(jsonDecode(json['properties']['equipment']))
+        : List<String>.from(json['properties']['equipment']))
     : [],
       ),
     );


### PR DESCRIPTION
## Summary

- **Favorites → Firestore**: Migrated from SharedPreferences to `users/{uid}/favorites` subcollection; favorites are tied to the user account and disabled when signed out
- **Favorite UI in panel header**: Heart toggle and live favorite count (bold, color-matched) moved inline next to the space type pill
- **Map layer refactor**: Replaced Mapbox tileset layers with runtime GeoJSON source using programmatic circle, marker, label, and selected-feature layers; slim GeoJSON endpoint (`?slim=true`) used for efficiency
- **On-demand space details**: Full space data (description, location, URL, amenities, details, equipment) fetched from Firestore when a space is selected, since the slim GeoJSON only carries `firestoreId`, `name`, and `type`
- **Borough derived from coordinates**: Bounding-box lookup (same as activity feed) instead of a missing database field; removed unused `borough` from `PublicSpaceProperties`
- **Z-ordering fix**: Annotation managers created after all style layers so heart badges render above map symbols
- **Fly-to-favorite fix**: `Future.delayed(400ms)` pattern ensures flyTo fires after tab switch

## Test plan

- [ ] Sign in and favorite a space — verify it persists after app restart
- [ ] Sign out — verify favorites list is empty and heart toggle is disabled (redirects to sign-in)
- [ ] Tap a favorite in the list — map flies to it and panel opens
- [ ] Open a space panel — description, location, URL, and amenities load correctly
- [ ] Favorite count appears next to heart and updates on toggle
- [ ] Borough shows correctly in favorites list for all 5 boroughs
- [ ] Map markers, labels, and selected-feature highlight render above base tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)